### PR TITLE
silentAiderRun on addCurrentFile if not running

### DIFF
--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -253,7 +253,7 @@ export async function main(denops: Denops): Promise<void> {
   }
 
   async function sendPromptFromFloatingWindow(): Promise<void> {
-    const bufnr = await getAiderBufferNr() ;
+    const bufnr = await getAiderBufferNr();
     if (bufnr === undefined) {
       return;
     }

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -306,6 +306,9 @@ export async function main(denops: Denops): Promise<void> {
     },
     async addCurrentFile(): Promise<void> {
       const bufnr = await fn.bufnr(denops, "%") as number;
+      if (await getAiderBufferNr() === undefined) {
+        await this.silentRunAider();
+      }
       const bufType = await fn.getbufvar(denops, bufnr, "&buftype") as string;
       if (bufType === "terminal") {
         return;

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -140,7 +140,6 @@ export async function main(denops: Denops): Promise<void> {
       ) as string;
 
       if (bufname.startsWith("term://")) {
-        await openFloatingWindow(denops, bufnr);
         return bufnr;
       }
     }
@@ -254,7 +253,11 @@ export async function main(denops: Denops): Promise<void> {
   }
 
   async function sendPromptFromFloatingWindow(): Promise<void> {
-    const bufnr = await getAiderBufferNr() as number;
+    const bufnr = await getAiderBufferNr() ;
+    if (bufnr === undefined) {
+      return;
+    }
+    await openFloatingWindow(denops, bufnr);
 
     await feedkeys(denops, "G");
     await feedkeys(denops, '"qp');
@@ -294,6 +297,8 @@ export async function main(denops: Denops): Promise<void> {
         await denops.cmd("AiderRun");
         return;
       }
+
+      await openFloatingWindow(denops, bufnr);
 
       openBufferType === "floating"
         ? sendPromptFromFloatingWindow()

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -343,7 +343,9 @@ export async function main(denops: Denops): Promise<void> {
     },
     async exit(): Promise<void> {
       const bufnr = await getAiderBufferNr();
-      await denops.cmd(`${bufnr}bdelete!`);
+      if (bufnr !== undefined) {
+        await denops.cmd(`${bufnr}bdelete!`);
+      }
     },
     async openIgnore(): Promise<void> {
       const gitRoot = (await fn.system(denops, "git rev-parse --show-toplevel"))


### PR DESCRIPTION
- Aiderが走っていないときに `:AiderAddCurrrentFile` を呼んだ場合にAiderが開くだけの動作をしていたのを、silentRunAiderしてaddCurrentFileする動作にします
- Aiderが走っているかどうかをチェックするのにgetAiderBufferNrを使おうとしたら関数内でopenFloatingWindowを呼んでいるのが邪魔で、かつgetする関数に副作用があるのは妙に感じたので外に移動しています
- ついでにaiderExitを二重に呼んだら出るエラーを解消しています

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling to prevent operations on undefined buffer numbers, reducing potential runtime errors.
  - Conditional checks added to ensure floating windows are only opened when valid buffer numbers are present.

- **Improvements**
  - Improved control flow for buffer management, ensuring safer and more reliable interactions with floating windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->