### PR TITLE
Avoid using `this` at all costs

### DIFF
--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -36,7 +36,7 @@ export const aiderCommand = {
   async addCurrentFile(denops: Denops): Promise<void> {
     const bufnr = await fn.bufnr(denops, "%");
     if (await getTerminalBufferNr(denops) === undefined) {
-      await this.run(denops);
+      await aiderCommand.run(denops);
     }
     const bufType = await fn.getbufvar(denops, bufnr, "&buftype");
     if (bufType === "terminal") {

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -122,7 +122,7 @@ export const buffer = {
   ): Promise<void | undefined | boolean> {
     const aiderBufnr = await getTerminalBufferNr(denops);
     if (aiderBufnr) {
-      await this.openFloatingWindow(denops, aiderBufnr);
+      await buffer.openFloatingWindow(denops, aiderBufnr);
       return true;
     }
 
@@ -136,7 +136,7 @@ export const buffer = {
       is.Number,
     );
 
-    await this.openFloatingWindow(
+    await buffer.openFloatingWindow(
       denops,
       bufnr,
     );
@@ -149,7 +149,7 @@ export const buffer = {
     if (bufnr === undefined) {
       return;
     }
-    await this.openFloatingWindow(denops, bufnr);
+    await buffer.openFloatingWindow(denops, bufnr);
 
     await feedkeys(denops, "G");
     await feedkeys(denops, '"qp');
@@ -213,12 +213,12 @@ export const buffer = {
       return;
     }
 
-    await this.openFloatingWindow(denops, bufnr);
+    await buffer.openFloatingWindow(denops, bufnr);
 
-    const openBufferType = await this.getOpenBufferType(denops);
+    const openBufferType = await buffer.getOpenBufferType(denops);
     openBufferType === "floating"
-      ? await this.sendPromptFromFloatingWindow(denops)
-      : await this.sendPromptFromSplitWindow(denops);
+      ? await buffer.sendPromptFromFloatingWindow(denops)
+      : await buffer.sendPromptFromSplitWindow(denops);
   },
   async sendPrompt(
     denops: Denops,
@@ -229,8 +229,8 @@ export const buffer = {
     await denops.cmd("bdelete!");
 
     openBufferType === "floating"
-      ? this.sendPromptFromFloatingWindow(denops)
-      : this.sendPromptFromSplitWindow(denops);
+      ? buffer.sendPromptFromFloatingWindow(denops)
+      : buffer.sendPromptFromSplitWindow(denops);
 
     return;
   },
@@ -264,7 +264,7 @@ export const buffer = {
       await n.nvim_create_buf(denops, false, true),
       is.Number,
     );
-    await this.openFloatingWindow(
+    await buffer.openFloatingWindow(
       denops,
       bufnr,
     );

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -42,7 +42,7 @@ export async function main(denops: Denops): Promise<void> {
       }
       const prompt = `/add ${path}`;
       await v.r.set(denops, "q", prompt);
-      await this.sendPromptWithInput();
+      await denops.dispatcher.sendPromptWithInput();
     },
     async addWeb(url: unknown): Promise<void> {
       if (url === "") {
@@ -50,7 +50,7 @@ export async function main(denops: Denops): Promise<void> {
       }
       const prompt = `/web ${url}`;
       await v.r.set(denops, "q", prompt);
-      await this.sendPromptWithInput();
+      await denops.dispatcher.sendPromptWithInput();
     },
     async exit(): Promise<void> {
       const bufnr = await getTerminalBufferNr(denops);


### PR DESCRIPTION
thisの扱いはjs/tsの各種複雑怪奇な謎仕様の中でも最も正気を失っている部分で、thisは定義時のオブジェクトを指すとは限らず、呼び出したタイミングの文脈で決まります。

具体的には関数がコールバックとして渡されて `f` などの名前にバインドされ、 `buffer.` や `aiderCommand.` などのプレフィクスなしで呼び出された場合、その関数内のthisはたぶんundefinedになります。

https://zenn.dev/convers39/articles/e0b7a26859f999 このあたり参考文献としてたぶん良さそうです(無駄に複雑かつ全体的にただのバグもいいところであり、知っていても一切役に立たないので私もすべて理解しているわけではないです)

thisには触れたら負けであると思ってください



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved method invocation by shifting from context-dependent references to explicit object references, enhancing readability and maintainability.
	- Streamlined control flow by removing unnecessary inner function declarations, simplifying the overall structure while maintaining functionality.

- **Bug Fixes**
	- Adjusted method calls to ensure consistent context resolution, potentially preventing execution issues related to misaligned context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->