### PR TITLE
checkIfAiderBuffer

### DIFF
--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -3,7 +3,7 @@ import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
 import { ensure, is } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
 import { getCurrentFilePath, getTerminalBufferNr } from "./utils.ts";
-import { buffer } from "./buffer.ts";
+import { buffer, checkIfAiderBuffer, checkIfTerminalBuffer } from "./buffer.ts";
 
 export const aiderCommand = {
   async debug(denops: Denops): Promise<void> {
@@ -51,8 +51,7 @@ export const aiderCommand = {
     if (await getTerminalBufferNr(denops) === undefined) {
       await aiderCommand.silentRun(denops);
     }
-    const bufType = await fn.getbufvar(denops, bufnr, "&buftype");
-    if (bufType === "terminal") {
+    if (await checkIfTerminalBuffer(denops, bufnr)) {
       return;
     }
     const currentFile = await getCurrentFilePath(denops);

--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -3,7 +3,7 @@ import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
 import { ensure, is } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
 import { getCurrentFilePath, getTerminalBufferNr } from "./utils.ts";
-import { buffer, checkIfAiderBuffer, checkIfTerminalBuffer } from "./buffer.ts";
+import { buffer, checkIfTerminalBuffer } from "./buffer.ts";
 
 export const aiderCommand = {
   async debug(denops: Denops): Promise<void> {

--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -2,7 +2,7 @@ import { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
 import { ensure, is } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
-import { getCurrentFilePath, getTerminalBufferNr } from "./utils.ts";
+import { getAiderBufferNr, getCurrentFilePath } from "./utils.ts";
 import { buffer, checkIfTerminalBuffer } from "./buffer.ts";
 
 export const aiderCommand = {
@@ -48,7 +48,7 @@ export const aiderCommand = {
    */
   async addCurrentFile(denops: Denops): Promise<void> {
     const bufnr = await fn.bufnr(denops, "%");
-    if (await getTerminalBufferNr(denops) === undefined) {
+    if (await getAiderBufferNr(denops) === undefined) {
       await aiderCommand.silentRun(denops);
     }
     if (await checkIfTerminalBuffer(denops, bufnr)) {

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -348,6 +348,7 @@ export async function checkIfAiderBuffer(
   denops: Denops,
   bufnr: number,
 ): Promise<boolean> {
+  // aiderバッファの場合 `term://{path}//{pid}:aider --4o --no-auto-commits` のような名前になっている
   const name = await getBufferName(denops, bufnr);
   const splitted = name.split(" ");
   return splitted[0].endsWith("aider");

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -7,7 +7,11 @@ import {
   is,
   maybe,
 } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
-import { getAdditionalPrompt, getAiderBufferNr } from "./utils.ts";
+import {
+  getAdditionalPrompt,
+  getAiderBufferNr,
+  getBufferName,
+} from "./utils.ts";
 import { feedkeys } from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
 
 /**
@@ -344,16 +348,8 @@ export async function checkIfAiderBuffer(
   denops: Denops,
   bufnr: number,
 ): Promise<boolean> {
-  // TODO try getname
-  const termInfo = maybe(
-    await fn.getbufinfo(denops, bufnr),
-    is.ArrayOf(is.ObjectOf({ name: is.String })),
-  );
-  if (termInfo === undefined || termInfo.length === 0) {
-    return false;
-  }
-  console.log(termInfo[0].name);
-  const splitted = termInfo[0].name.split(" ");
+  const name = await getBufferName(denops, bufnr);
+  const splitted = name.split(" ");
   return splitted[0].endsWith("aider");
 }
 

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -340,7 +340,7 @@ async function identifyAiderBuffer(
  * @param {number} bufnr - バッファ番号
  * @returns {Promise<boolean>}
  */
-async function checkIfAiderBuffer(
+export async function checkIfAiderBuffer(
   denops: Denops,
   bufnr: number,
 ): Promise<boolean> {
@@ -348,7 +348,7 @@ async function checkIfAiderBuffer(
     await fn.getbufinfo(denops, bufnr),
     is.ArrayOf(is.ObjectOf({ name: is.String })),
   );
-  if (termInfo === undefined) {
+  if (termInfo === undefined || termInfo.length === 0) {
     return false;
   }
   console.log(termInfo[0].name);

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -7,7 +7,7 @@ import {
   is,
   maybe,
 } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
-import { getAdditionalPrompt, getTerminalBufferNr } from "./utils.ts";
+import { getAdditionalPrompt, getAiderBufferNr } from "./utils.ts";
 import { feedkeys } from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
 
 /**
@@ -120,7 +120,7 @@ export const buffer = {
     denops: Denops,
     openBufferType: BufferLayout,
   ): Promise<void | undefined | boolean> {
-    const aiderBufnr = await getTerminalBufferNr(denops);
+    const aiderBufnr = await getAiderBufferNr(denops);
     if (aiderBufnr) {
       await buffer.openFloatingWindow(denops, aiderBufnr);
       return true;
@@ -145,7 +145,7 @@ export const buffer = {
   },
 
   async sendPromptFromFloatingWindow(denops: Denops): Promise<void> {
-    const bufnr = await getTerminalBufferNr(denops);
+    const bufnr = await getAiderBufferNr(denops);
     if (bufnr === undefined) {
       return;
     }
@@ -206,7 +206,7 @@ export const buffer = {
   },
 
   async sendPromptWithInput(denops: Denops): Promise<void> {
-    const bufnr = await getTerminalBufferNr(denops);
+    const bufnr = await getAiderBufferNr(denops);
     if (bufnr === undefined) {
       await denops.cmd("echo 'Aider is not running'");
       await denops.cmd("AiderRun");
@@ -245,7 +245,7 @@ export const buffer = {
       is.ArrayOf(is.String),
     );
     if (openBufferType !== "floating") {
-      const bufnr = await getTerminalBufferNr(denops);
+      const bufnr = await getAiderBufferNr(denops);
       if (bufnr === undefined) {
         await denops.cmd("echo 'Aider is not running'");
         await denops.cmd("AiderRun");
@@ -344,6 +344,7 @@ export async function checkIfAiderBuffer(
   denops: Denops,
   bufnr: number,
 ): Promise<boolean> {
+  // TODO try getname
   const termInfo = maybe(
     await fn.getbufinfo(denops, bufnr),
     is.ArrayOf(is.ObjectOf({ name: is.String })),

--- a/denops/aider/utils.ts
+++ b/denops/aider/utils.ts
@@ -46,7 +46,7 @@ export async function getBufferName(
  * @param {Denops} denops - The Denops instance.
  * @returns {Promise<number | undefined>} The buffer number or undefined.
  */
-export async function getTerminalBufferNr(
+export async function getAiderBufferNr(
   denops: Denops,
 ): Promise<number | undefined> {
   // Get all open buffer numbers

--- a/denops/aider/utils.ts
+++ b/denops/aider/utils.ts
@@ -2,6 +2,7 @@ import { Denops } from "https://deno.land/x/denops_std@v6.4.0/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
 import { ensure, is } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
+import { checkIfAiderBuffer } from "./buffer.ts";
 
 /**
  * Gets the additional prompt from vim global variable "aider_additional_prompt".
@@ -56,9 +57,8 @@ export async function getTerminalBufferNr(
 
   for (let i = 1; i <= buf_count; i++) {
     const bufnr = ensure(await fn.bufnr(denops, i), is.Number);
-    const bufname = await getBufferName(denops, bufnr);
 
-    if (bufname.startsWith("term://")) {
+    if (await checkIfAiderBuffer(denops, bufnr)) {
       return bufnr;
     }
   }

--- a/denops/aider/utils.ts
+++ b/denops/aider/utils.ts
@@ -40,7 +40,7 @@ export async function getBufferName(
 }
 
 /**
- * Gets the buffer number of the first buffer with a name starting with "term://".
+ * Gets the buffer number of the first buffer that matches the condition of checkIfAiderBuffer.
  * If no matching buffer is found, the function returns undefined.
  *
  * @param {Denops} denops - The Denops instance.


### PR DESCRIPTION
- getBufferNameを使ってaiderのバッファかどうか確認するcheckIfAiderBufferと、buftypeを見るcheckIfTerminalBufferを追加しました
- 既存のbuftypeのチェックをしていた場所を基本的にすべてcheckIfAiderBufferに変更し、addCurrentFileでターミナルバッファの場合何もしない処理の部分だけcheckIfTerminalBufferのままにしています
- それに合わせていくつかリネームをしています
- とりあえず手元ではugatermのターミナルバッファとaiderが混線する不具合が解消しています
- あと関係ないけどAiderExitとかAiderSendPromptWithInputとかが動かなくなってそう
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced buffer identification for Aider buffers, improving specificity in buffer management.
	- Added a new function to check if a buffer is an Aider buffer.
  
- **Bug Fixes**
	- Improved the logic for retrieving buffer numbers, ensuring accurate identification of Aider buffers.

- **Refactor**
	- Renamed functions to better reflect their purpose related to Aider buffers, enhancing code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->