### PR TITLE
feat: aiderHide コマンドを追加 🆕

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ nnoremap <silent> <leader>aw :AiderAddWeb<CR>
 nnoremap <silent> <leader>ax :AiderExit<CR>
 nnoremap <silent> <leader>ai :AiderAddIgnoreCurrentFile<CR>
 nnoremap <silent> <leader>aI :AiderOpenIgnore<CR>
+nnoremap <silent> <leader>ah :AiderHide<CR>
 vmap <leader>av :AiderVisualTextWithPrompt<CR>
 ```
 

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -2,6 +2,7 @@ import { Denops } from "https://deno.land/x/denops_std@v6.4.0/mod.ts";
 import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
 import { aiderCommand } from "./aiderCommand.ts";
 import { buffer, BufferLayout } from "./buffer.ts";
+import { feedkeys } from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
 
 /**
  * The main function that sets up the Aider plugin functionality.
@@ -51,6 +52,10 @@ export async function main(denops: Denops): Promise<void> {
     },
     async exit(): Promise<void> {
       await buffer.exitAiderBuffer(denops);
+    },
+    async hide(): Promise<void> {
+      await denops.cmd("close!");
+      await denops.cmd(`silent! e!`);
     },
     async debug(): Promise<void> {
       await aiderCommand.debug(denops);
@@ -109,5 +114,8 @@ export async function main(denops: Denops): Promise<void> {
   );
   await denops.cmd(
     `command! -nargs=* -range AiderDebug call denops#notify("${denops.name}", "debug", [])`,
+  );
+  await denops.cmd(
+    `command! -nargs=* -range AiderHide call denops#notify("${denops.name}", "hide", [])`,
   );
 }


### PR DESCRIPTION
- aiderのflaoting windowを非表示にするとき、同時にバッファを再読み込みするコマンドを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command `AiderHide` for quickly hiding the Aider interface in the text editor.
	- Added a key mapping `<leader>ah` to invoke the `AiderHide` functionality, enhancing usability.
  
- **Bug Fixes**
	- Improved overall responsiveness of the Aider plugin with the new `hide` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->