### PR TITLE
autocmd User AiderOpen

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,6 @@ Please add the following settings to your lazy settings.
     vim.g.aider_buffer_open_type = 'floating'
     vim.g.aider_floatwin_width = 100
     vim.g.aider_floatwin_height = 20
-    vim.api.nvim_set_keymap('n', '<leader>ar', ':AiderRun<CR>', { noremap = true, silent = true })
-    vim.api.nvim_set_keymap('n', '<leader>aa', ':AiderAddCurrentFile<CR>', { noremap = true, silent = true })
-    vim.api.nvim_set_keymap('n', '<leader>aw', ':AiderAddWeb<CR>', { noremap = true, silent = true })
-    vim.api.nvim_set_keymap('n', '<leader>ask', ':AiderAsk ', { noremap = true, silent = true })
-    vim.api.nvim_set_keymap('n', '<leader>ase', ':AiderSendPrompt ', { noremap = true, silent = true })
 
     vim.api.nvim_create_autocmd('User',
       {
@@ -71,6 +66,14 @@ Please add the following settings to your lazy settings.
               vim.keymap.set('n', '<Esc>', '<cmd>AiderHide<CR>', { buffer = args.buf })
             end
       })
+    vim.api.nvim_set_keymap('n', '<leader>ar', ':AiderRun<CR>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', '<leader>aa', ':AiderAddCurrentFile<CR>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', '<leader>aw', ':AiderAddWeb<CR>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', '<leader>ax', ':AiderExit<CR>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', '<leader>ai', ':AiderAddIgnoreCurrentFile<CR>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', '<leader>aI', ':AiderOpenIgnore<CR>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', '<leader>ah', ':AiderHide<CR>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('v', '<leader>av', ':AiderVisualTextWithPrompt<CR>', { noremap = true, silent = true })
   end
   }
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Minimal helper plugin for aider with neovim.
 
 ## Settings
 
+### vimscript
 Please add the following settings to your vimrc or init.vim.
 
 ```vim
@@ -42,6 +43,36 @@ function! s:AiderOpenHandler() abort
   execute 'tnoremap <buffer=' . a:args.buf . '> <Esc> <C-\><C-n>'
   execute 'nnoremap <buffer=' . a:args.buf . '> <Esc> :AiderHide<CR>'
 endfunction
+```
+
+### lua (lazy.nvim)
+Please add the following settings to your lazy settings.
+
+```lua
+{ "nekowasabi/aider.vim"
+  , dependencies = "vim-denops/denops.vim"
+  , config = function()
+    vim.g.aider_command = 'aider --no-auto-commits'
+    vim.g.aider_buffer_open_type = 'floating'
+    vim.g.aider_floatwin_width = 100
+    vim.g.aider_floatwin_height = 20
+    vim.api.nvim_set_keymap('n', '<leader>ar', ':AiderRun<CR>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', '<leader>aa', ':AiderAddCurrentFile<CR>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', '<leader>aw', ':AiderAddWeb<CR>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', '<leader>ask', ':AiderAsk ', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', '<leader>ase', ':AiderSendPrompt ', { noremap = true, silent = true })
+
+    vim.api.nvim_create_autocmd('User',
+      {
+        pattern = 'AiderOpen',
+        callback =
+            function(args)
+              vim.keymap.set('t', '<Esc>', '<C-\\><C-n>', { buffer = args.buf })
+              vim.keymap.set('n', '<Esc>', '<cmd>AiderHide<CR>', { buffer = args.buf })
+            end
+      })
+  end
+  }
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ nnoremap <silent> <leader>ai :AiderAddIgnoreCurrentFile<CR>
 nnoremap <silent> <leader>aI :AiderOpenIgnore<CR>
 nnoremap <silent> <leader>ah :AiderHide<CR>
 vmap <leader>av :AiderVisualTextWithPrompt<CR>
+augroup AiderOpenGroup
+  autocmd!
+  autocmd User AiderOpen call s:AiderOpenHandler()
+augroup END
+
+function! s:AiderOpenHandler() abort
+  " Set key mappings for the buffer
+  execute 'tnoremap <buffer=' . a:args.buf . '> <Esc> <C-\><C-n>'
+  execute 'nnoremap <buffer=' . a:args.buf . '> <Esc> :AiderHide<CR>'
+endfunction
 ```
 
 ## Usage

--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -3,7 +3,7 @@ import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
 import { ensure, is } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
 import { getAiderBufferNr, getCurrentFilePath } from "./utils.ts";
-import { buffer, checkIfTerminalBuffer } from "./buffer.ts";
+import { buffer } from "./buffer.ts";
 
 export const aiderCommand = {
   async debug(denops: Denops): Promise<void> {
@@ -51,7 +51,7 @@ export const aiderCommand = {
     if (await getAiderBufferNr(denops) === undefined) {
       await aiderCommand.silentRun(denops);
     }
-    if (await checkIfTerminalBuffer(denops, bufnr)) {
+    if (await buffer.checkIfTerminalBuffer(denops, bufnr)) {
       return;
     }
     const currentFile = await getCurrentFilePath(denops);

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -1,5 +1,6 @@
 import { Denops } from "https://deno.land/x/denops_std@v6.4.0/mod.ts";
 import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
+import { emit } from "https://deno.land/x/denops_std@v6.5.1/autocmd/mod.ts";
 import * as n from "https://deno.land/x/denops_std@v6.4.0/function/nvim/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
 import {
@@ -133,11 +134,13 @@ export const buffer = {
     const aiderBufnr = await getAiderBufferNr(denops);
     if (aiderBufnr) {
       await buffer.openFloatingWindow(denops, aiderBufnr);
+      await emit(denops, "User", "AiderOpen");
       return true;
     }
 
     if (openBufferType === "split" || openBufferType === "vsplit") {
       await denops.cmd(openBufferType);
+      await emit(denops, "User", "AiderOpen");
       return;
     }
 
@@ -151,6 +154,7 @@ export const buffer = {
       bufnr,
     );
 
+    await emit(denops, "User", "AiderOpen");
     return;
   },
 

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -275,8 +275,6 @@ async function openFloatingWindow(
   const col = Math.floor((terminal_width - floatWinWidth) / 2);
 
   await n.nvim_open_win(denops, bufnr, true, {
-    title:
-      "| normal mode > qq: quit, terminal mode > <Esc><Esc>: quit | visual mode > <CR>: send prompt |",
     relative: "editor",
     border: "double",
     width: floatWinWidth,
@@ -284,36 +282,6 @@ async function openFloatingWindow(
     row: row,
     col: col,
   });
-  await n.nvim_buf_set_keymap(
-    denops,
-    bufnr,
-    "t",
-    "<Esc>",
-    "<cmd>close!<cr>",
-    {
-      silent: true,
-    },
-  );
-  await n.nvim_buf_set_keymap(
-    denops,
-    bufnr,
-    "n",
-    "q",
-    "<cmd>close!<cr>",
-    {
-      silent: true,
-    },
-  );
-  await n.nvim_buf_set_keymap(
-    denops,
-    bufnr,
-    "n",
-    "<Esc>",
-    "<cmd>close!<cr>",
-    {
-      silent: true,
-    },
-  );
 
   await denops.cmd("set nonumber");
 }

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -112,6 +112,7 @@ export const buffer = {
       ? sendPromptFromFloatingWindow(denops)
       : sendPromptFromSplitWindow(denops);
 
+    await emit("User", "AiderOpen");
     return;
   },
   async openFloatingWindowWithSelectedCode(

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -28,92 +28,19 @@ export type BufferLayout = typeof bufferLayouts[number];
  * floating: floating window
  */
 export const buffer = {
-  async exitAiderBuffer(denops: Denops): Promise<void> {
-    await identifyAiderBuffer(denops, async (job_id, _winnr, bufnr) => {
-      await denops.call("chansend", job_id, "/exit\n");
-      await denops.cmd(`bdelete! ${bufnr}`);
-    });
-  },
   async getOpenBufferType(denops: Denops): Promise<BufferLayout> {
     return maybe(
       await v.g.get(denops, "aider_buffer_open_type"),
       is.LiteralOneOf(bufferLayouts),
     ) ?? "floating";
   },
-
-  /**
-   * Opens a floating window for the specified buffer.
-   * The floating window is positioned at the center of the terminal.
-   *
-   * @param {Denops} denops - The Denops instance.
-   * @param {number} bufnr - The buffer number.
-   * @returns {Promise<void>}
-   */
-  async openFloatingWindow(
-    denops: Denops,
-    bufnr: number,
-  ): Promise<void> {
-    const terminal_width = Math.floor(
-      ensure(await n.nvim_get_option(denops, "columns"), is.Number),
-    );
-    const terminal_height = Math.floor(
-      ensure(await n.nvim_get_option(denops, "lines"), is.Number),
-    );
-    const floatWinHeight = ensure(
-      await v.g.get(denops, "aider_floatwin_height"),
-      is.Number,
-    );
-    const floatWinWidth = ensure(
-      await v.g.get(denops, "aider_floatwin_width"),
-      is.Number,
-    );
-
-    const row = Math.floor((terminal_height - floatWinHeight) / 2);
-    const col = Math.floor((terminal_width - floatWinWidth) / 2);
-
-    await n.nvim_open_win(denops, bufnr, true, {
-      title:
-        "| normal mode > qq: quit, terminal mode > <Esc><Esc>: quit | visual mode > <CR>: send prompt |",
-      relative: "editor",
-      border: "double",
-      width: floatWinWidth,
-      height: floatWinHeight,
-      row: row,
-      col: col,
+  async exitAiderBuffer(denops: Denops): Promise<void> {
+    await identifyAiderBuffer(denops, async (job_id, _winnr, bufnr) => {
+      await denops.call("chansend", job_id, "/exit\n");
+      await denops.cmd(`bdelete! ${bufnr}`);
     });
-    await n.nvim_buf_set_keymap(
-      denops,
-      bufnr,
-      "t",
-      "<Esc>",
-      "<cmd>close!<cr>",
-      {
-        silent: true,
-      },
-    );
-    await n.nvim_buf_set_keymap(
-      denops,
-      bufnr,
-      "n",
-      "q",
-      "<cmd>close!<cr>",
-      {
-        silent: true,
-      },
-    );
-    await n.nvim_buf_set_keymap(
-      denops,
-      bufnr,
-      "n",
-      "<Esc>",
-      "<cmd>close!<cr>",
-      {
-        silent: true,
-      },
-    );
-
-    await denops.cmd("set nonumber");
   },
+
   /**
    * Opens an Aider buffer.
    * If an Aider buffer is already open, it opens that buffer.
@@ -133,7 +60,7 @@ export const buffer = {
   ): Promise<void | undefined | boolean> {
     const aiderBufnr = await getAiderBufferNr(denops);
     if (aiderBufnr) {
-      await buffer.openFloatingWindow(denops, aiderBufnr);
+      await openFloatingWindow(denops, aiderBufnr);
       await emit(denops, "User", "AiderOpen");
       return true;
     }
@@ -149,74 +76,13 @@ export const buffer = {
       is.Number,
     );
 
-    await buffer.openFloatingWindow(
+    await openFloatingWindow(
       denops,
       bufnr,
     );
 
     await emit(denops, "User", "AiderOpen");
     return;
-  },
-
-  async sendPromptFromFloatingWindow(denops: Denops): Promise<void> {
-    const bufnr = await getAiderBufferNr(denops);
-    if (bufnr === undefined) {
-      return;
-    }
-    await buffer.openFloatingWindow(denops, bufnr);
-
-    await feedkeys(denops, "G");
-    await feedkeys(denops, '"qp');
-
-    const jobId = ensure(
-      await fn.getbufvar(denops, bufnr, "&channel"),
-      is.Number,
-    );
-
-    await denops.call("chansend", jobId, "\n");
-  },
-
-  /**
-   * スプリットウィンドウからプロンプトを送信する非同期関数
-   *
-   * この関数は以下の操作を行います：
-   * 1. ターミナルバッファを識別
-   * 2. 現在のバッファを閉じる
-   * 3. ターミナルウィンドウに移動
-   * 4. カーソルを最後に移動
-   * 5. レジスタ 'q' の内容を貼り付け
-   * 6. Enter キーを送信
-   * 7. 元のウィンドウに戻る
-   *
-   * @param {Denops} denops - Denopsインスタンス
-   */
-  async sendPromptFromSplitWindow(denops: Denops): Promise<void> {
-    await identifyAiderBuffer(denops, async (job_id, winnr, _bufnr) => {
-      await denops.cmd(`bdelete!`);
-      if (await v.g.get(denops, "aider_buffer_open_type") !== "floating") {
-        await denops.cmd(`${winnr}wincmd w`);
-      } else {
-        const totalWindows = ensure<number>(
-          await denops.call("winnr", "$"),
-          is.Number,
-        );
-
-        for (let winnr = 1; winnr <= totalWindows; winnr++) {
-          const bufnr = await denops.call("winbufnr", winnr);
-
-          const buftype = await denops.call("getbufvar", bufnr, "&buftype");
-
-          if (buftype === "terminal") {
-            await denops.cmd(`${winnr}wincmd w`);
-            break;
-          }
-        }
-      }
-      await feedkeys(denops, "G");
-      await feedkeys(denops, '"qp');
-      await denops.call("chansend", job_id, "\n");
-      await denops.cmd("wincmd p");
-    });
   },
 
   async sendPromptWithInput(denops: Denops): Promise<void> {
@@ -227,12 +93,12 @@ export const buffer = {
       return;
     }
 
-    await buffer.openFloatingWindow(denops, bufnr);
-
     const openBufferType = await buffer.getOpenBufferType(denops);
+    await buffer.openAiderBuffer(denops, openBufferType);
+
     openBufferType === "floating"
-      ? await buffer.sendPromptFromFloatingWindow(denops)
-      : await buffer.sendPromptFromSplitWindow(denops);
+      ? await sendPromptFromFloatingWindow(denops)
+      : await sendPromptFromSplitWindow(denops);
   },
   async sendPrompt(
     denops: Denops,
@@ -243,8 +109,8 @@ export const buffer = {
     await denops.cmd("bdelete!");
 
     openBufferType === "floating"
-      ? buffer.sendPromptFromFloatingWindow(denops)
-      : buffer.sendPromptFromSplitWindow(denops);
+      ? sendPromptFromFloatingWindow(denops)
+      : sendPromptFromSplitWindow(denops);
 
     return;
   },
@@ -278,7 +144,7 @@ export const buffer = {
       await n.nvim_create_buf(denops, false, true),
       is.Number,
     );
-    await buffer.openFloatingWindow(
+    await openFloatingWindow(
       denops,
       bufnr,
     );
@@ -316,6 +182,35 @@ export const buffer = {
       },
     );
   },
+  /**
+   * バッファがAiderバッファかどうかを確認します。
+   * @param {Denops} denops - Denopsインスタンス
+   * @param {number} bufnr - バッファ番号
+   * @returns {Promise<boolean>}
+   */
+  async checkIfAiderBuffer(
+    denops: Denops,
+    bufnr: number,
+  ): Promise<boolean> {
+    // aiderバッファの場合 `term://{path}//{pid}:aider --4o --no-auto-commits` のような名前になっている
+    const name = await getBufferName(denops, bufnr);
+    const splitted = name.split(" ");
+    return splitted[0].endsWith("aider");
+  },
+
+  /**
+   * バッファがターミナルバッファかどうかを確認します。
+   * @param {Denops} denops - Denopsインスタンス
+   * @param {number} bufnr - バッファ番号
+   * @returns {Promise<boolean>}
+   */
+  async checkIfTerminalBuffer(
+    denops: Denops,
+    bufnr: number,
+  ): Promise<boolean> {
+    const buftype = await fn.getbufvar(denops, bufnr, "&buftype");
+    return buftype === "terminal";
+  },
 };
 
 /**
@@ -336,7 +231,7 @@ async function identifyAiderBuffer(
   for (let i = 1; i <= win_count; i++) {
     const bufnr = ensure(await fn.winbufnr(denops, i), is.Number);
 
-    if (await checkIfAiderBuffer(denops, bufnr)) {
+    if (await buffer.checkIfAiderBuffer(denops, bufnr)) {
       const job_id = ensure<number>(
         await fn.getbufvar(denops, bufnr, "&channel"),
         is.Number,
@@ -349,31 +244,134 @@ async function identifyAiderBuffer(
 }
 
 /**
- * バッファがAiderバッファかどうかを確認します。
- * @param {Denops} denops - Denopsインスタンス
- * @param {number} bufnr - バッファ番号
- * @returns {Promise<boolean>}
+ * Opens a floating window for the specified buffer.
+ * The floating window is positioned at the center of the terminal.
+ *
+ * @param {Denops} denops - The Denops instance.
+ * @param {number} bufnr - The buffer number.
+ * @returns {Promise<void>}
  */
-export async function checkIfAiderBuffer(
+async function openFloatingWindow(
   denops: Denops,
   bufnr: number,
-): Promise<boolean> {
-  // aiderバッファの場合 `term://{path}//{pid}:aider --4o --no-auto-commits` のような名前になっている
-  const name = await getBufferName(denops, bufnr);
-  const splitted = name.split(" ");
-  return splitted[0].endsWith("aider");
-}
+): Promise<void> {
+  const terminal_width = Math.floor(
+    ensure(await n.nvim_get_option(denops, "columns"), is.Number),
+  );
+  const terminal_height = Math.floor(
+    ensure(await n.nvim_get_option(denops, "lines"), is.Number),
+  );
+  const floatWinHeight = ensure(
+    await v.g.get(denops, "aider_floatwin_height"),
+    is.Number,
+  );
+  const floatWinWidth = ensure(
+    await v.g.get(denops, "aider_floatwin_width"),
+    is.Number,
+  );
 
+  const row = Math.floor((terminal_height - floatWinHeight) / 2);
+  const col = Math.floor((terminal_width - floatWinWidth) / 2);
+
+  await n.nvim_open_win(denops, bufnr, true, {
+    title:
+      "| normal mode > qq: quit, terminal mode > <Esc><Esc>: quit | visual mode > <CR>: send prompt |",
+    relative: "editor",
+    border: "double",
+    width: floatWinWidth,
+    height: floatWinHeight,
+    row: row,
+    col: col,
+  });
+  await n.nvim_buf_set_keymap(
+    denops,
+    bufnr,
+    "t",
+    "<Esc>",
+    "<cmd>close!<cr>",
+    {
+      silent: true,
+    },
+  );
+  await n.nvim_buf_set_keymap(
+    denops,
+    bufnr,
+    "n",
+    "q",
+    "<cmd>close!<cr>",
+    {
+      silent: true,
+    },
+  );
+  await n.nvim_buf_set_keymap(
+    denops,
+    bufnr,
+    "n",
+    "<Esc>",
+    "<cmd>close!<cr>",
+    {
+      silent: true,
+    },
+  );
+
+  await denops.cmd("set nonumber");
+}
+async function sendPromptFromFloatingWindow(denops: Denops): Promise<void> {
+  const bufnr = await getAiderBufferNr(denops);
+  if (bufnr === undefined) {
+    return;
+  }
+  await openFloatingWindow(denops, bufnr);
+
+  await feedkeys(denops, "G");
+  await feedkeys(denops, '"qp');
+
+  const jobId = ensure(
+    await fn.getbufvar(denops, bufnr, "&channel"),
+    is.Number,
+  );
+
+  await denops.call("chansend", jobId, "\n");
+}
 /**
- * バッファがターミナルバッファかどうかを確認します。
+ * スプリットウィンドウからプロンプトを送信する非同期関数
+ *
+ * この関数は以下の操作を行います：
+ * 1. ターミナルバッファを識別
+ * 2. 現在のバッファを閉じる
+ * 3. ターミナルウィンドウに移動
+ * 4. カーソルを最後に移動
+ * 5. レジスタ 'q' の内容を貼り付け
+ * 6. Enter キーを送信
+ * 7. 元のウィンドウに戻る
+ *
  * @param {Denops} denops - Denopsインスタンス
- * @param {number} bufnr - バッファ番号
- * @returns {Promise<boolean>}
  */
-export async function checkIfTerminalBuffer(
-  denops: Denops,
-  bufnr: number,
-): Promise<boolean> {
-  const buftype = await fn.getbufvar(denops, bufnr, "&buftype");
-  return buftype === "terminal";
+async function sendPromptFromSplitWindow(denops: Denops): Promise<void> {
+  await identifyAiderBuffer(denops, async (job_id, winnr, _bufnr) => {
+    await denops.cmd(`bdelete!`);
+    if (await v.g.get(denops, "aider_buffer_open_type") !== "floating") {
+      await denops.cmd(`${winnr}wincmd w`);
+    } else {
+      const totalWindows = ensure<number>(
+        await denops.call("winnr", "$"),
+        is.Number,
+      );
+
+      for (let winnr = 1; winnr <= totalWindows; winnr++) {
+        const bufnr = await denops.call("winbufnr", winnr);
+
+        const buftype = await denops.call("getbufvar", bufnr, "&buftype");
+
+        if (buftype === "terminal") {
+          await denops.cmd(`${winnr}wincmd w`);
+          break;
+        }
+      }
+    }
+    await feedkeys(denops, "G");
+    await feedkeys(denops, '"qp');
+    await denops.call("chansend", job_id, "\n");
+    await denops.cmd("wincmd p");
+  });
 }

--- a/denops/aider/utils.ts
+++ b/denops/aider/utils.ts
@@ -2,7 +2,7 @@ import { Denops } from "https://deno.land/x/denops_std@v6.4.0/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
 import { ensure, is } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
-import { checkIfAiderBuffer } from "./buffer.ts";
+import { buffer } from "./buffer.ts";
 
 /**
  * Gets the additional prompt from vim global variable "aider_additional_prompt".
@@ -58,7 +58,7 @@ export async function getAiderBufferNr(
   for (let i = 1; i <= buf_count; i++) {
     const bufnr = ensure(await fn.bufnr(denops, i), is.Number);
 
-    if (await checkIfAiderBuffer(denops, bufnr)) {
+    if (await buffer.checkIfAiderBuffer(denops, bufnr)) {
       return bufnr;
     }
   }


### PR DESCRIPTION
- Aiderバッファを開くときにUser AiderOpen autocmdを射出するようになります 🐕 
- これを利用したkeymap設定方法をREADMEに追加します
- floatingのデフォルトkeymapは思い切って消してしまっています(異論あればrevertします)
- 各bufferコマンドの後に1回だけautocmdを射出しようとするとsendPromptFromFloatingWindowなどのprivateであるべき関数がbuffer内にあってexportされているのがとても邪魔だったので外に出しています 
   - 見た目差分多いですが cedbd36406076490bc5572ba93c93549f3468b08 でのこのリファクタ以外はemitが増えてkeymapが消えただけです

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options for the Aider plugin, enhancing user experience with key mappings and terminal interactions.
	- Added utility functions to improve buffer type checks, streamlining the interaction with Aider buffers.

- **Bug Fixes**
	- Resolved issues related to window positioning and display settings for the Aider plugin.

- **Documentation**
	- Updated the README.md to reflect new configuration settings and usage instructions for the Aider plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->