### PR TITLE
Over engineered main

### DIFF
--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -9,14 +9,14 @@ import { buffer, BufferLayout } from "./buffer.ts";
  * @returns {Promise<void>}
  */
 export async function main(denops: Denops): Promise<void> {
-  type ImplType =
-    | (() => Promise<void>)
-    | ((arg: unknown) => Promise<void>)
-    | ((args: unknown[]) => Promise<void>);
+  type ArgCount = "0" | "1" | "*";
+  type ImplType<T extends ArgCount> = T extends "0" ? (() => Promise<void>)
+    : T extends "1" ? ((arg: string) => Promise<void>)
+    : ((args: string[]) => Promise<void>);
 
   type Command = {
     methodName: string;
-    impl: ImplType;
+    impl: ImplType<ArgCount>;
   };
 
   /**
@@ -28,9 +28,10 @@ export async function main(denops: Denops): Promise<void> {
    * @param {boolean} [range=false] - コマンドがVisualモードで動作するかどうか。
    * @returns {Promise<Command>} - メソッド名、`command!`宣言、実装を含むコマンドオブジェクト。
    */
-  async function command(
+  async function command<argCount extends ArgCount>(
     dispatcherMethod: string,
-    impl: ImplType,
+    argCount: argCount,
+    impl: ImplType<argCount>,
     pattern: "[<f-args>]" | "[<line1>, <line2>]" | "[]" = "[]",
     range: boolean = false,
   ): Promise<Command> {
@@ -38,12 +39,9 @@ export async function main(denops: Denops): Promise<void> {
 
     const commandName = "Aider" + dispatcherMethod.charAt(0).toUpperCase() +
       dispatcherMethod.slice(1);
-    const argCount = (() => {
-      if (impl.length === 0) return "0";
-      if (impl.length === 1) return "1";
-      else return "*";
-    })();
-
+    console.log(
+      `command! -nargs=${argCount} ${rangePart} ${commandName} call denops#notify("${denops.name}", "${dispatcherMethod}", ${pattern})`,
+    );
     await denops.cmd(
       `command! -nargs=${argCount} ${rangePart} ${commandName} call denops#notify("${denops.name}", "${dispatcherMethod}", ${pattern})`,
     );
@@ -62,7 +60,7 @@ export async function main(denops: Denops): Promise<void> {
    */
   function dispatchOnly(
     dispatcherMethod: string,
-    impl: ImplType,
+    impl: ImplType<ArgCount>,
   ): Command {
     return {
       methodName: dispatcherMethod,
@@ -75,39 +73,46 @@ export async function main(denops: Denops): Promise<void> {
   const commands: Command[] = [
     await command(
       "sendPrompt",
+      "0",
       () => buffer.sendPrompt(denops, openBufferType),
     ),
-    await command("run", async () => {
+    await command("run", "0", async () => {
       if (await buffer.openAiderBuffer(denops, openBufferType)) {
         return;
       }
       await aiderCommand.run(denops);
     }),
-    await command("silentRun", () => aiderCommand.silentRun(denops)),
+    await command("silentRun", "0", () => aiderCommand.silentRun(denops)),
     dispatchOnly(
       "sendPromptWithInput",
       () => buffer.sendPromptWithInput(denops),
     ),
-    await command("addFile", async (path: unknown) => {
+    await command("addFile", "1", async (path: string) => {
       const prompt = `/add ${path}`;
       await v.r.set(denops, "q", prompt);
       await denops.dispatcher.sendPromptWithInput(path);
     }, "[<f-args>]"),
-    await command("addCurrentFile", () => aiderCommand.addCurrentFile(denops)),
-    await command("addWeb", async (url: unknown) => {
+    await command(
+      "addCurrentFile",
+      "0",
+      () => aiderCommand.addCurrentFile(denops),
+    ),
+    await command("addWeb", "1", async (url: string) => {
       const prompt = `/web ${url}`;
       await v.r.set(denops, "q", prompt);
       await denops.dispatcher.sendPromptWithInput(url);
     }, "[<f-args>]"),
-    await command("ask", async (question: unknown) => {
+    await command("ask", "1", async (question: string) => {
       const prompt = `/ask ${question}`;
       await v.r.set(denops, "q", prompt);
       await denops.dispatcher.sendPromptWithInput(question);
     }, "[<f-args>]"),
-    await command("exit", () => buffer.exitAiderBuffer(denops)),
+    await command("exit", "0", () => buffer.exitAiderBuffer(denops)),
     await command(
       "openFloatingWindowWithSelectedCode",
-      async ([start, end]: unknown[]) => {
+      "*",
+      async ([start, end]: string[]) => {
+        console.log([start, end]);
         await buffer.openFloatingWindowWithSelectedCode(
           denops,
           start,
@@ -118,13 +123,14 @@ export async function main(denops: Denops): Promise<void> {
       "[<line1>, <line2>]",
       true,
     ),
-    await command("openIgnore", () => aiderCommand.openIgnore(denops)),
+    await command("openIgnore", "0", () => aiderCommand.openIgnore(denops)),
     await command(
       "addIgnoreCurrentFile",
+      "0",
       () => aiderCommand.addIgnoreCurrentFile(denops),
     ),
-    await command("debug", () => aiderCommand.debug(denops)),
-    await command("hide", async () => {
+    await command("debug", "0", () => aiderCommand.debug(denops)),
+    await command("hide", "0", async () => {
       await denops.cmd("close!");
       await denops.cmd(`silent! e!`);
     }),

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -88,10 +88,6 @@ export async function main(denops: Denops): Promise<void> {
       () => buffer.sendPromptWithInput(denops),
     ),
     await command("addFile", async (path: unknown) => {
-      console.log(path);
-      if (path === "") {
-        return;
-      }
       const prompt = `/add ${path}`;
       await v.r.set(denops, "q", prompt);
       await denops.dispatcher.sendPromptWithInput(path);

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -14,10 +14,6 @@ export async function main(denops: Denops): Promise<void> {
     | ((arg: unknown) => Promise<void>)
     | ((args: unknown[]) => Promise<void>);
 
-  type ArgCount<T extends ImplType> = T extends () => Promise<void> ? "0"
-    : T extends (arg: unknown) => Promise<void> ? "1"
-    : "*";
-
   type Command = {
     methodName: string;
     impl: ImplType;
@@ -39,13 +35,14 @@ export async function main(denops: Denops): Promise<void> {
     range: boolean = false,
   ): Promise<Command> {
     const rangePart = range ? "-range " : "";
+
     const commandName = "Aider" + dispatcherMethod.charAt(0).toUpperCase() +
       dispatcherMethod.slice(1);
     const argCount = (() => {
       if (impl.length === 0) return "0";
       if (impl.length === 1) return "1";
       else return "*";
-    })() as ArgCount<T>;
+    })();
 
     await denops.cmd(
       `command! -nargs=${argCount} ${rangePart} ${commandName} call denops#notify("${denops.name}", "${dispatcherMethod}", ${pattern})`,

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -39,9 +39,6 @@ export async function main(denops: Denops): Promise<void> {
 
     const commandName = "Aider" + dispatcherMethod.charAt(0).toUpperCase() +
       dispatcherMethod.slice(1);
-    console.log(
-      `command! -nargs=${argCount} ${rangePart} ${commandName} call denops#notify("${denops.name}", "${dispatcherMethod}", ${pattern})`,
-    );
     await denops.cmd(
       `command! -nargs=${argCount} ${rangePart} ${commandName} call denops#notify("${denops.name}", "${dispatcherMethod}", ${pattern})`,
     );
@@ -112,7 +109,6 @@ export async function main(denops: Denops): Promise<void> {
       "visualTextWithPrompt",
       "*",
       async ([start, end]: string[]) => {
-        console.log([start, end]);
         await buffer.openFloatingWindowWithSelectedCode(
           denops,
           start,

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -117,33 +117,16 @@ export async function main(denops: Denops): Promise<void> {
       "[<line1>, <line2>]",
       true,
     ),
-    command(
-      "openIgnore",
-      (_args: unknown[]) => aiderCommand.openIgnore(denops),
-      "[<f-args>]",
-      true,
-    ),
+    command("openIgnore", () => aiderCommand.openIgnore(denops)),
     command(
       "addIgnoreCurrentFile",
-      (_args: unknown[]) => aiderCommand.addIgnoreCurrentFile(denops),
-      "[<f-args>]",
-      true,
+      () => aiderCommand.addIgnoreCurrentFile(denops),
     ),
-    command(
-      "debug",
-      (_args: unknown[]) => aiderCommand.debug(denops),
-      "[<f-args>]",
-      true,
-    ),
-    command(
-      "hide",
-      async (_args: unknown[]) => {
-        await denops.cmd("close!");
-        await denops.cmd(`silent! e!`);
-      },
-      "[<f-args>]",
-      true,
-    ),
+    command("debug", () => aiderCommand.debug(denops)),
+    command("hide", async () => {
+      await denops.cmd("close!");
+      await denops.cmd(`silent! e!`);
+    }),
   ];
 
   denops.dispatcher = Object.fromEntries(commands.map((command) => [

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -57,6 +57,12 @@ export async function main(denops: Denops): Promise<void> {
     };
   }
 
+  /**
+   * Denopsディスパッチャー用のコマンドを生成します。command!宣言は生成されません。
+   * @param {string} dispatcherMethod - ディスパッチャーで使用されるメソッド名。
+   * @param {T} impl - コマンドの実装関数。
+   * @returns {Command<T>} - メソッド名、command!宣言、実装を含むコマンドオブジェクト。
+   */
   function dispatchOnly<T extends ImplType>(
     dispatcherMethod: string,
     impl: T,

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -109,7 +109,7 @@ export async function main(denops: Denops): Promise<void> {
     }, "[<f-args>]"),
     await command("exit", "0", () => buffer.exitAiderBuffer(denops)),
     await command(
-      "openFloatingWindowWithSelectedCode",
+      "visualTextWithPrompt",
       "*",
       async ([start, end]: string[]) => {
         console.log([start, end]);

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -78,6 +78,29 @@ export async function main(denops: Denops): Promise<void> {
     },
   };
 
+  /**
+   * The main function that sets up the Aider plugin functionality.
+   * @param {Denops} denops - The Denops instance.
+   * @returns {Promise<void>}
+   */
+  function declCommand(
+    denops: Denops,
+    dispatcherMethod: string,
+    args: "0" | "1" | {
+      tag: "*";
+      pattern: "[<f-args>]" | "[<line1>, <line2>]";
+    } = "0",
+    range: boolean = false,
+  ): Promise<void> {
+    const rangePart = range ? "-range " : "";
+    const commandName = dispatcherMethod.charAt(0).toUpperCase() +
+      dispatcherMethod.slice(1);
+    const nargsUsage = args === "0" || args === "1" ? args : args.pattern;
+    return denops.cmd(
+      `command! -nargs=${args} ${rangePart} ${commandName} call denops#notify("${denops.name}", "${dispatcherMethod}", ${nargsUsage})`,
+    );
+  }
+
   await denops.cmd(
     `command! -nargs=0 AiderSendPrompt call denops#notify("${denops.name}", "sendPrompt", [])`,
   );

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -20,17 +20,17 @@ export async function main(denops: Denops): Promise<void> {
   };
 
   /**
-   * Denopsディスパッチャー用のコマンドとcommand!宣言を生成します。
+   * Denopsディスパッチャー用のコマンドと`command!`宣言を生成します。
    *
-   * @param {string} dispatcherMethod - ディスパッチャーで使用されるメソッド名。vim側に見えるコマンド名は Aider + DispatcherMethod のようになります。
-   * @param {(args: ArgType<T>) => Promise<void>} impl - コマンドの実装関数。
-   * @param {"[<f-args>]" | "[<line1>, <line2>]" | ""} [pattern=""] - コマンドの引数パターン。
-   * @param {boolean} [range=false] - コマンドがvisual modeで動作するかどうか。
-   * @returns {Command<T>} - メソッド名、command!宣言、実装を含むコマンドオブジェクト。
+   * @param {string} dispatcherMethod - ディスパッチャーで使用されるメソッド名。Vim側に見えるコマンド名は Aider + DispatcherMethod のようになります。
+   * @param {ImplType} impl - コマンドの実装関数。
+   * @param {"[<f-args>]" | "[<line1>, <line2>]" | "[]"} [pattern="[]"] - コマンドの引数パターン。
+   * @param {boolean} [range=false] - コマンドがVisualモードで動作するかどうか。
+   * @returns {Promise<Command>} - メソッド名、`command!`宣言、実装を含むコマンドオブジェクト。
    */
-  async function command<T extends ImplType>(
+  async function command(
     dispatcherMethod: string,
-    impl: T,
+    impl: ImplType,
     pattern: "[<f-args>]" | "[<line1>, <line2>]" | "[]" = "[]",
     range: boolean = false,
   ): Promise<Command> {
@@ -54,14 +54,15 @@ export async function main(denops: Denops): Promise<void> {
   }
 
   /**
-   * Denopsディスパッチャー用のコマンドを生成します。command!宣言は生成されません。
+   * Denopsディスパッチャー用のコマンドを生成します。`command!`宣言は生成されません。
+   *
    * @param {string} dispatcherMethod - ディスパッチャーで使用されるメソッド名。
-   * @param {T} impl - コマンドの実装関数。
-   * @returns {Command<T>} - メソッド名、command!宣言、実装を含むコマンドオブジェクト。
+   * @param {ImplType} impl - コマンドの実装関数。
+   * @returns {Command} - メソッド名と実装を含むコマンドオブジェクト。
    */
-  function dispatchOnly<T extends ImplType>(
+  function dispatchOnly(
     dispatcherMethod: string,
-    impl: T,
+    impl: ImplType,
   ): Command {
     return {
       methodName: dispatcherMethod,


### PR DESCRIPTION
- dispatcherとcommand!の定義で似たようなことを2回書いているのがいやだったのでオーバーエンジニアリングしてみました
- command関数でcommand!宣言をしつつ  `type Command = { methodName: string; impl: ImplType;  };` のArrayを作り、そこから `Object.fromEntries` でdenops.dispatcherオブジェクトを作っています

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced command handling with dynamic command registration for improved flexibility and modularity.
	- Introduced new command types for streamlined implementation and argument handling.
	- Added functions to simplify command creation and registration processes.

- **Bug Fixes**
	- Resolved issues related to static command definitions, improving command registration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->