### PR TITLE
fix: await sendPromptFromFloatingWindow and sendPromptFromSplitWindow

### DIFF
--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -109,8 +109,8 @@ export const buffer = {
     await denops.cmd("bdelete!");
 
     openBufferType === "floating"
-      ? sendPromptFromFloatingWindow(denops)
-      : sendPromptFromSplitWindow(denops);
+      ? await sendPromptFromFloatingWindow(denops)
+      : await sendPromptFromSplitWindow(denops);
 
     await emit(denops, "User", "AiderOpen");
     return;


### PR DESCRIPTION
AiderSendPrompt後にバッファがちょっと変になるような気がしたのでよく見たらawaitが抜けてました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of buffer management by ensuring prompts are fully processed before emitting user events. 

This change enhances the user experience by maintaining the correct sequence of events in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->