### PR TITLE
AiderTest command

### DIFF
--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -95,7 +95,7 @@ export async function main(denops: Denops): Promise<void> {
       async (path: string) => {
         const prompt = `/add ${path}`;
         await v.r.set(denops, "q", prompt);
-        await denops.dispatcher.sendPromptWithInput(denops);
+        await denops.dispatcher.sendPromptWithInput();
       },
       "[<f-args>]",
       false,
@@ -109,12 +109,12 @@ export async function main(denops: Denops): Promise<void> {
     await command("addWeb", "1", async (url: string) => {
       const prompt = `/web ${url}`;
       await v.r.set(denops, "q", prompt);
-      await denops.dispatcher.sendPromptWithInput(denops);
+      await denops.dispatcher.sendPromptWithInput();
     }, "[<f-args>]"),
     await command("ask", "1", async (question: string) => {
       const prompt = `/ask ${question}`;
       await v.r.set(denops, "q", prompt);
-      await denops.dispatcher.sendPromptWithInput(denops);
+      await denops.dispatcher.sendPromptWithInput();
     }, "[<f-args>]"),
     await command("exit", "0", () => buffer.exitAiderBuffer(denops)),
     await command(
@@ -148,7 +148,7 @@ export async function main(denops: Denops): Promise<void> {
       async (cmd: string) => {
         const prompt = `/test ${cmd}`;
         await v.r.set(denops, "q", prompt);
-        await denops.dispatcher.sendPromptWithInput(denops);
+        await denops.dispatcher.sendPromptWithInput();
       },
       "[<f-args>]",
       false,

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -95,7 +95,7 @@ export async function main(denops: Denops): Promise<void> {
       async (path: string) => {
         const prompt = `/add ${path}`;
         await v.r.set(denops, "q", prompt);
-        await denops.dispatcher.sendPromptWithInput(path);
+        await denops.dispatcher.sendPromptWithInput(denops);
       },
       "[<f-args>]",
       false,
@@ -109,12 +109,12 @@ export async function main(denops: Denops): Promise<void> {
     await command("addWeb", "1", async (url: string) => {
       const prompt = `/web ${url}`;
       await v.r.set(denops, "q", prompt);
-      await denops.dispatcher.sendPromptWithInput(url);
+      await denops.dispatcher.sendPromptWithInput(denops);
     }, "[<f-args>]"),
     await command("ask", "1", async (question: string) => {
       const prompt = `/ask ${question}`;
       await v.r.set(denops, "q", prompt);
-      await denops.dispatcher.sendPromptWithInput(question);
+      await denops.dispatcher.sendPromptWithInput(denops);
     }, "[<f-args>]"),
     await command("exit", "0", () => buffer.exitAiderBuffer(denops)),
     await command(
@@ -145,8 +145,10 @@ export async function main(denops: Denops): Promise<void> {
     await command(
       "test",
       "1",
-      async () => {
-        await aiderCommand.simpleCommand(denops, "/test");
+      async (cmd: string) => {
+        const prompt = `/test ${cmd}`;
+        await v.r.set(denops, "q", prompt);
+        await denops.dispatcher.sendPromptWithInput(denops);
       },
       "[<f-args>]",
       false,

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -43,7 +43,7 @@ export async function main(denops: Denops): Promise<void> {
 
     const commandName = "Aider" + dispatcherMethod.charAt(0).toUpperCase() +
       dispatcherMethod.slice(1);
-    const completePart = complete ? "" : `-complete=${complete}`;
+    const completePart = complete === "" ? "" : `-complete=${complete}`;
     await denops.cmd(
       `command! -nargs=${argCount} ${completePart} ${rangePart} ${commandName} call denops#notify("${denops.name}", "${dispatcherMethod}", ${pattern})`,
     );

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -12,7 +12,7 @@ export async function main(denops: Denops): Promise<void> {
   type ArgCount = "0" | "1" | "*";
   type ImplType<T extends ArgCount> = T extends "0" ? (() => Promise<void>)
     : T extends "1" ? ((arg: string) => Promise<void>)
-    : ((arg: string, arg2: string) => Promise<void>); // MEMO: 1つめの引数、2つめの引数という意味 ArgCountは*だが現状2つのみ対応している
+    : ((arg: string, arg2: string) => Promise<void>); // MEMO: ArgCountは*だが現状2つのみ対応している
   type CompleteType<T extends ArgCount> = T extends "1"
     ? "file" | "shellcmd" | ""
     : "";


### PR DESCRIPTION
- `/test` が便利そうだったので追加したり、commandにcompleteが欲しかったのでtestとついでにaddfileに設定したりしました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command `test` for setting prompts with completion options.
	- Enhanced command registration to support completion types for better user experience.

- **Bug Fixes**
	- Streamlined command implementations by removing unnecessary parameters from the `sendPromptWithInput` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->