### PR TITLE
fix getAdditionalPrompt on no prompt is set

### DIFF
--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -157,10 +157,7 @@ export const buffer = {
     await n.nvim_buf_set_lines(denops, bufnr, 0, 1, true, []);
     await n.nvim_buf_set_lines(denops, bufnr, -1, -1, true, [""]);
 
-    const additionalPrompt = ensure(
-      await getAdditionalPrompt(denops),
-      is.String,
-    );
+    const additionalPrompt = await getAdditionalPrompt(denops);
     if (additionalPrompt) {
       await n.nvim_buf_set_lines(denops, bufnr, -1, -1, true, ["# rule"]);
       await n.nvim_buf_set_lines(denops, bufnr, -1, -1, true, [

--- a/denops/aider/utils.ts
+++ b/denops/aider/utils.ts
@@ -1,6 +1,10 @@
 import { Denops } from "https://deno.land/x/denops_std@v6.4.0/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
-import { ensure, is } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
+import {
+  ensure,
+  is,
+  maybe,
+} from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
 import { buffer } from "./buffer.ts";
 
@@ -10,8 +14,10 @@ import { buffer } from "./buffer.ts";
  * @param {Denops} denops - The Denops instance.
  * @returns {Promise<string>} A promise that resolves to the current file path.
  */
-export async function getAdditionalPrompt(denops: Denops): Promise<string> {
-  return ensure(await v.g.get(denops, "aider_additional_prompt"), is.String);
+export async function getAdditionalPrompt(
+  denops: Denops,
+): Promise<string | undefined> {
+  return maybe(await v.g.get(denops, "aider_additional_prompt"), is.String);
 }
 
 /**


### PR DESCRIPTION
additionalPromptが定義されていなかったときエラーになるのを修正しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of additional prompts, allowing for more flexible responses that may now include `undefined`.
  
- **Bug Fixes**
	- Simplified assignment logic for additional prompts, improving overall code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->