### PR TITLE
Refactor

### DIFF
--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -26,22 +26,6 @@ export const aiderCommand = {
     await denops.call("chansend", jobId, "\n");
   },
 
-  /**
-   * .aiderignoreファイルを開きます。
-   * ファイルが存在する場合は編集モードで開き、存在しない場合はエラーメッセージを表示します。
-   * @param {Denops} denops - Denopsインスタンス
-   * @returns {Promise<void>}
-   */
-  async openIgnore(denops: Denops): Promise<void> {
-    const gitRoot = (await fn.system(denops, "git rev-parse --show-toplevel"))
-      .trim();
-    const filePathToOpen = `${gitRoot}/.aiderignore`;
-    if (await fn.filereadable(denops, filePathToOpen)) {
-      await denops.cmd(`edit ${filePathToOpen}`);
-      return;
-    }
-    console.log(".aiderignoreファイルが見つかりません。");
-  },
 
   async run(denops: Denops): Promise<void> {
     const aiderCommand = ensure(

--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -8,25 +8,6 @@ export const aiderCommand = {
     await denops.cmd("b#");
   },
 
-  /**
-   * Aiderバッファにメッセージを送信します。
-   * @param {Denops} denops - Denops instance
-   * @param {number} jobId - The job id to send the message to
-   * @param {string} prompt - The prompt to send
-   * @returns {Promise<void>}
-   */
-  async sendPrompt(
-    denops: Denops,
-    jobId: number,
-    prompt: string,
-  ): Promise<void> {
-    await v.r.set(denops, "q", prompt);
-    await fn.feedkeys(denops, "G");
-    await fn.feedkeys(denops, '"qp');
-    await denops.call("chansend", jobId, "\n");
-  },
-
-
   async run(denops: Denops): Promise<void> {
     const aiderCommand = ensure(
       await v.g.get(denops, "aider_command"),
@@ -53,5 +34,22 @@ export const aiderCommand = {
     await denops.cmd("b#");
 
     await denops.cmd("echo 'Aider is running in the background.'");
+  },
+  /**
+   * Aiderバッファにメッセージを送信します。
+   * @param {Denops} denops - Denops instance
+   * @param {number} jobId - The job id to send the message to
+   * @param {string} prompt - The prompt to send
+   * @returns {Promise<void>}
+   */
+  async sendPrompt(
+    denops: Denops,
+    jobId: number,
+    prompt: string,
+  ): Promise<void> {
+    await v.r.set(denops, "q", prompt);
+    await fn.feedkeys(denops, "G");
+    await fn.feedkeys(denops, '"qp');
+    await denops.call("chansend", jobId, "\n");
   },
 };

--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -11,6 +11,22 @@ export const aiderCommand = {
   },
 
   /**
+   * Aiderバッファにメッセージを送信します。
+   * @param {Denops} denops - Denops instance
+   * @param {number} jobId - The job id to send the message to
+   * @param {string} prompt - The prompt to send
+   * @returns {Promise<void>}
+   */
+  async sendPrompt(
+    denops: Denops,
+    jobId: number,
+    prompt: string,
+  ): Promise<void> {
+    await v.r.set(denops, "q", prompt);
+    await denops.call("chansend", jobId, "\n");
+  },
+
+  /**
    * .aiderignoreファイルを開きます。
    * ファイルが存在する場合は編集モードで開き、存在しない場合はエラーメッセージを表示します。
    * @param {Denops} denops - Denopsインスタンス

--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -2,8 +2,6 @@ import { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
 import { ensure, is } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
-import { getAiderBufferNr, getCurrentFilePath } from "./utils.ts";
-import { buffer } from "./buffer.ts";
 
 export const aiderCommand = {
   async debug(denops: Denops): Promise<void> {

--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -1,4 +1,4 @@
-import { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import { Denops } from "https://deno.land/x/denops_std@v6.4.0/mod.ts";
 import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
 import { ensure, is } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
@@ -20,7 +20,11 @@ export const aiderCommand = {
     jobId: number,
     prompt: string,
   ): Promise<void> {
+    console.log(prompt);
+    console.log(jobId);
     await v.r.set(denops, "q", prompt);
+    await fn.feedkeys(denops, "G");
+    await fn.feedkeys(denops, '"qp');
     await denops.call("chansend", jobId, "\n");
   },
 

--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -52,4 +52,9 @@ export const aiderCommand = {
     await fn.feedkeys(denops, '"qp');
     await denops.call("chansend", jobId, "\n");
   },
+
+  async exit(denops: Denops, jobId: number, bufnr: number): Promise<void> {
+    await denops.call("chansend", jobId, "/exit\n");
+    await denops.cmd(`bdelete! ${bufnr}`);
+  },
 };

--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -54,36 +54,4 @@ export const aiderCommand = {
 
     await denops.cmd("echo 'Aider is running in the background.'");
   },
-  /**
-   * 現在のファイルをAiderに追加します。
-   * @param {Denops} denops - Denopsインスタンス
-   * @returns {Promise<void>}
-   */
-  async addCurrentFile(denops: Denops): Promise<void> {
-    const bufnr = await fn.bufnr(denops, "%");
-    if (await getAiderBufferNr(denops) === undefined) {
-      await aiderCommand.silentRun(denops);
-    }
-    if (await buffer.checkIfTerminalBuffer(denops, bufnr)) {
-      return;
-    }
-    const currentFile = await getCurrentFilePath(denops);
-    const prompt = `/add ${currentFile}`;
-    await v.r.set(denops, "q", prompt);
-    await buffer.sendPromptWithInput(denops);
-  },
-  async addIgnoreCurrentFile(denops: Denops): Promise<void> {
-    const currentFile = await getCurrentFilePath(denops);
-
-    const gitRoot = (await fn.system(denops, "git rev-parse --show-toplevel"))
-      .trim();
-    const filePathToOpen = `${gitRoot}/.aiderignore`;
-    const forAiderIgnorePath = currentFile.replace(gitRoot, "");
-
-    const file = await fn.readfile(denops, filePathToOpen);
-    file.push(`!${forAiderIgnorePath}`);
-
-    await fn.writefile(denops, file, filePathToOpen);
-    console.log(`Added ${currentFile} to .aiderignore`);
-  },
 };

--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -20,8 +20,6 @@ export const aiderCommand = {
     jobId: number,
     prompt: string,
   ): Promise<void> {
-    console.log(prompt);
-    console.log(jobId);
     await v.r.set(denops, "q", prompt);
     await fn.feedkeys(denops, "G");
     await fn.feedkeys(denops, '"qp');

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -1,6 +1,6 @@
 import { Denops } from "https://deno.land/x/denops_std@v6.4.0/mod.ts";
 import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
-import { emit } from "https://deno.land/x/denops_std@v6.5.1/autocmd/mod.ts";
+import { emit } from "https://deno.land/x/denops_std@v6.4.0/autocmd/mod.ts";
 import * as n from "https://deno.land/x/denops_std@v6.4.0/function/nvim/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
 import {

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -35,10 +35,11 @@ export const buffer = {
     ) ?? "floating";
   },
   async exitAiderBuffer(denops: Denops): Promise<void> {
-    await identifyAiderBuffer(denops, async (job_id, _winnr, bufnr) => {
-      await denops.call("chansend", job_id, "/exit\n"); // TODO!!!
+    const buffers = await identifyAiderBuffer(denops);
+    for (const { job_id, bufnr } of buffers) {
+      await denops.call("chansend", job_id, "/exit\n");
       await denops.cmd(`bdelete! ${bufnr}`);
-    });
+    }
   },
 
   /**
@@ -324,8 +325,8 @@ async function sendPromptFromSplitWindow(
   denops: Denops,
   prompt: string,
 ): Promise<void> {
-  await identifyAiderBuffer(denops, async (job_id, winnr, _bufnr) => {
-    // await denops.cmd(`bdelete!`);
+  const buffers = await identifyAiderBuffer(denops);
+  for (const { job_id, winnr } of buffers) {
     if (await v.g.get(denops, "aider_buffer_open_type") !== "floating") {
       await denops.cmd(`${winnr}wincmd w`);
     } else {

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -218,7 +218,7 @@ export const buffer = {
 /**
  * 開いているウィンドウの中からAiderバッファを識別し、そのジョブID、ウィンドウ番号、バッファ番号を返します。
  *
- * @returns {Promise<Array<{ job_id: number, winnr: number, bufnr: number }>>}
+ * @returns {Promise<{ job_id: number, winnr: number, bufnr: number }>}
  */
 async function identifyAiderBuffer(
   denops: Denops,

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -41,8 +41,7 @@ export const buffer = {
       return;
     }
     const { job_id, bufnr } = buffer;
-    await denops.call("chansend", job_id, "/exit\n");
-    await denops.cmd(`bdelete! ${bufnr}`);
+    aiderCommand.exit(denops, job_id, bufnr);
   },
 
   /**

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -108,13 +108,11 @@ export const buffer = {
     denops: Denops,
     openBufferType: BufferLayout,
   ): Promise<void> {
-    // Get the buffer content as a string
     const bufferContent = ensure(
       await denops.call("getbufline", "%", 1, "$"),
       is.ArrayOf(is.String),
     ).join("\n");
 
-    // Close the prompt input window
     await denops.cmd("bdelete!");
 
     if (openBufferType === "floating") {

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -80,10 +80,7 @@ export const buffer = {
       is.Number,
     );
 
-    await openFloatingWindow(
-      denops,
-      bufnr,
-    );
+    await openFloatingWindow(denops, bufnr);
 
     await emit(denops, "User", "AiderOpen");
     return;
@@ -297,7 +294,7 @@ async function sendPromptFromFloatingWindow(
   await feedkeys(denops, '"qp');
 
   const jobId = ensure(
-    await fn.getbufvar(denops, bufnr, "&channel"), // TODO!!!
+    await fn.getbufvar(denops, bufnr, "&channel"),
     is.Number,
   );
   try {

--- a/denops/aider/buffer.ts
+++ b/denops/aider/buffer.ts
@@ -104,7 +104,7 @@ export const buffer = {
 
     await sendPromptFromSplitWindow(denops, input);
   },
-  async sendPrompt(
+  async sendPromptByBuffer(
     denops: Denops,
     openBufferType: BufferLayout,
   ): Promise<void> {
@@ -297,9 +297,6 @@ async function sendPromptFromFloatingWindow(
   }
   await openFloatingWindow(denops, bufnr);
 
-  await feedkeys(denops, "G");
-  await feedkeys(denops, '"qp');
-
   const jobId = ensure(
     await fn.getbufvar(denops, bufnr, "&channel"),
     is.Number,
@@ -349,8 +346,5 @@ async function sendPromptFromSplitWindow(
       }
     }
   }
-  await feedkeys(denops, "G");
-  await feedkeys(denops, '"qp');
   await aiderCommand.sendPrompt(denops, job_id, prompt);
-  await denops.cmd("wincmd p");
 }

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -64,7 +64,7 @@ export async function main(denops: Denops): Promise<void> {
     await command(
       "sendPrompt",
       "0",
-      () => buffer.sendPrompt(denops, openBufferType),
+      () => buffer.sendPromptByBuffer(denops, openBufferType),
     ),
     await command("run", "0", async () => {
       if (await buffer.openAiderBuffer(denops, openBufferType)) {

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -98,7 +98,6 @@ export async function main(denops: Denops): Promise<void> {
         await buffer.sendPromptWithInput(denops, prompt);
       },
     ),
-
     await command(
       "addWeb",
       "1",

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -131,7 +131,16 @@ export async function main(denops: Denops): Promise<void> {
       },
       { pattern: "[<line1>, <line2>]", range: true },
     ),
-    await command("openIgnore", "0", () => aiderCommand.openIgnore(denops)),
+    await command("openIgnore", "0", async () => {
+      const gitRoot = (await fn.system(denops, "git rev-parse --show-toplevel"))
+        .trim();
+      const filePathToOpen = `${gitRoot}/.aiderignore`;
+      if (await fn.filereadable(denops, filePathToOpen)) {
+        await denops.cmd(`edit ${filePathToOpen}`);
+        return;
+      }
+      console.log(".aiderignoreファイルが見つかりません。");
+    }),
     await command(
       "addIgnoreCurrentFile",
       "0",

--- a/tests/aider_test.ts
+++ b/tests/aider_test.ts
@@ -2,7 +2,7 @@ import { assert, assertEquals, assertFalse } from "jsr:@std/assert";
 import { test } from "jsr:@denops/test";
 import { getCurrentFilePath } from "../denops/aider/utils.ts";
 
-test("vim", "Start Vim to test denops features", async (denops) => {
+test("nvim", "Start NeoVim to test denops features", async (denops) => {
   const path = await getCurrentFilePath(denops);
   assertEquals(path, "");
 });


### PR DESCRIPTION
#17
- aiderCommand.sendPromptを追加し、そこまではinputをstringで持ち回る形にしました
- 同様にaiderCommand.exitを追加しました
- aiderCommand.openIgnore, addCurrentFile, addIgnoreCurrentFileは各コマンドに特有の実装なためmainに移動しました
- identifyAiderBufferがcallbackを取っていたのが不要そうだったのでバッファのレコードを返す形にしました
- ついでにテストファイルは名前が_testで終わっていないと認識されないようだったのでtests/aider_test.tsにリネームしました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new methods for sending prompts and exiting jobs, enhancing command handling.
	- Improved functionality for managing Aider buffers and commands.

- **Bug Fixes**
	- Removed outdated command handling related to `.aiderignore`, streamlining user experience.

- **Documentation**
	- Updated test case to reflect NeoVim context, ensuring clarity in testing environment.

- **Refactor**
	- Consolidated command registration and improved buffer management logic for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->