### PR TITLE
destruct aiderCommand and buffer object, use import as instead

### DIFF
--- a/denops/aider/aiderCommand.ts
+++ b/denops/aider/aiderCommand.ts
@@ -3,58 +3,58 @@ import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
 import { ensure, is } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
 
-export const aiderCommand = {
-  async debug(denops: Denops): Promise<void> {
-    await denops.cmd("b#");
-  },
+export async function debug(denops: Denops): Promise<void> {
+  await denops.cmd("b#");
+}
 
-  async run(denops: Denops): Promise<void> {
-    const aiderCommand = ensure(
-      await v.g.get(denops, "aider_command"),
-      is.String,
-    );
-    await denops.cmd(`terminal ${aiderCommand}`);
-  },
-  /**
-   * Aiderをバックグラウンドで実行します。
-   * 新しいバッファを作成し、Aiderコマンドをターミナルで実行した後、
-   * 前のバッファに戻ります。
-   * @param {Denops} denops - Denopsインスタンス
-   * @returns {Promise<void>}
-   */
-  async silentRun(denops: Denops): Promise<void> {
-    await denops.cmd("enew");
+export async function run(denops: Denops): Promise<void> {
+  const aiderCommand = ensure(
+    await v.g.get(denops, "aider_command"),
+    is.String,
+  );
+  await denops.cmd(`terminal ${aiderCommand}`);
+}
 
-    const aiderCommand = ensure(
-      await v.g.get(denops, "aider_command"),
-      is.String,
-    );
-    await denops.cmd(`terminal ${aiderCommand}`);
+/**
+ * Aiderをバックグラウンドで実行します。
+ * 新しいバッファを作成し、Aiderコマンドをターミナルで実行した後、
+ * 前のバッファに戻ります。
+ * @param {Denops} denops - Denopsインスタンス
+ * @returns {Promise<void>}
+ */
+export async function silentRun(denops: Denops): Promise<void> {
+  await denops.cmd("enew");
 
-    await denops.cmd("b#");
+  const aiderCommand = ensure(
+    await v.g.get(denops, "aider_command"),
+    is.String,
+  );
+  await denops.cmd(`terminal ${aiderCommand}`);
 
-    await denops.cmd("echo 'Aider is running in the background.'");
-  },
-  /**
-   * Aiderバッファにメッセージを送信します。
-   * @param {Denops} denops - Denops instance
-   * @param {number} jobId - The job id to send the message to
-   * @param {string} prompt - The prompt to send
-   * @returns {Promise<void>}
-   */
-  async sendPrompt(
-    denops: Denops,
-    jobId: number,
-    prompt: string,
-  ): Promise<void> {
-    await v.r.set(denops, "q", prompt);
-    await fn.feedkeys(denops, "G");
-    await fn.feedkeys(denops, '"qp');
-    await denops.call("chansend", jobId, "\n");
-  },
+  await denops.cmd("b#");
 
-  async exit(denops: Denops, jobId: number, bufnr: number): Promise<void> {
-    await denops.call("chansend", jobId, "/exit\n");
-    await denops.cmd(`bdelete! ${bufnr}`);
-  },
-};
+  await denops.cmd("echo 'Aider is running in the background.'");
+}
+
+/**
+ * Aiderバッファにメッセージを送信します。
+ * @param {Denops} denops - Denops instance
+ * @param {number} jobId - The job id to send the message to
+ * @param {string} prompt - The prompt to send
+ * @returns {Promise<void>}
+ */
+export async function sendPrompt(
+  denops: Denops,
+  jobId: number,
+  prompt: string,
+): Promise<void> {
+  await v.r.set(denops, "q", prompt);
+  await fn.feedkeys(denops, "G");
+  await fn.feedkeys(denops, '"qp');
+  await denops.call("chansend", jobId, "\n");
+}
+
+export async function exit(denops: Denops, jobId: number, bufnr: number): Promise<void> {
+  await denops.call("chansend", jobId, "/exit\n");
+  await denops.cmd(`bdelete! ${bufnr}`);
+}

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -1,7 +1,8 @@
 import { Denops } from "https://deno.land/x/denops_std@v6.4.0/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.4.0/function/mod.ts";
-import { aiderCommand } from "./aiderCommand.ts";
-import { buffer, BufferLayout } from "./buffer.ts";
+import * as aiderCommand from "./aiderCommand.ts";
+import * as buffer from "./buffer.ts";
+import { BufferLayout } from "./buffer.ts";
 import { getAiderBufferNr, getCurrentFilePath } from "./utils.ts";
 
 /**

--- a/denops/aider/utils.ts
+++ b/denops/aider/utils.ts
@@ -6,7 +6,7 @@ import {
   maybe,
 } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import * as v from "https://deno.land/x/denops_std@v6.4.0/variable/mod.ts";
-import { buffer } from "./buffer.ts";
+import * as buffer from "./buffer.ts";
 
 /**
  * Gets the additional prompt from vim global variable "aider_additional_prompt".


### PR DESCRIPTION
- リファクタなどの際に妙に差分が多くなるのがやや不満なのでaiderCommand, bufferオブジェクトにまとめてexportしているのをexport functionする形にしてみます
- importする際にimport * as buffer from ...のようにすることで使用箇所では同じように使えます
- hide whitespaceすると差分が読みやすいです
<img width="370" alt="スクリーンショット 2024-10-04 22 36 55" src="https://github.com/user-attachments/assets/8f4b746d-73db-45ed-9450-55616de0b942">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Individual functions for managing Aider commands and buffers are now directly exported, enhancing modularity and ease of use.
  
- **Bug Fixes**
	- Improved logic for opening buffers, ensuring the correct window type is displayed based on user input.

- **Documentation**
	- Comments associated with functions have been preserved for clarity.

- **Chores**
	- Updated import statements to utilize module imports for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->