### PR TITLE
refactor openAiderBuffer, small fix getAiderBuffer

### DIFF
--- a/denops/aider/bufferOperation.ts
+++ b/denops/aider/bufferOperation.ts
@@ -57,11 +57,20 @@ export async function openAiderBuffer(
   openBufferType: BufferLayout,
 ): Promise<void> {
   const aiderBuf = await getAiderBuffer(denops);
-  // TODO openBufferTypeで大きく分岐するようリファクタすべき
-  // return typeもbooleanにできる
-  if (aiderBuf && openBufferType === "floating") {
-    await openFloatingWindow(denops, aiderBuf.bufnr);
-    return;
+  if (openBufferType === "floating") {
+    if (aiderBuf === undefined) {
+      const bufnr = ensure(
+        await n.nvim_create_buf(denops, false, true),
+        is.Number,
+      );
+      await openFloatingWindow(denops, bufnr);
+      await aider().run(denops);
+      return;
+    }
+    if (aiderBuf !== undefined) {
+      await openFloatingWindow(denops, aiderBuf.bufnr);
+      return;
+    }
   }
 
   if (openBufferType === "split" || openBufferType === "vsplit") {
@@ -73,12 +82,6 @@ export async function openAiderBuffer(
     await aider().run(denops);
     return;
   }
-
-  const bufnr = ensure(await n.nvim_create_buf(denops, false, true), is.Number);
-
-  await openFloatingWindow(denops, bufnr);
-  await aider().run(denops);
-  return;
 }
 
 export async function sendPromptWithInput(

--- a/denops/aider/bufferOperation.ts
+++ b/denops/aider/bufferOperation.ts
@@ -410,7 +410,8 @@ export async function getAiderBuffer(
       // プロセスが動いていない場合(session復元時など)はバッファを削除
       if (!aider().isTestMode() && jobId === 0) {
         await denops.cmd(`b ${bufnr}`);
-        await denops.cmd("bp | sp | bn | bd!"); // delete buffer without changing window
+        await denops.cmd("b#");
+        await denops.cmd("bd! #");
         continue;
       }
 

--- a/denops/aider/bufferOperation.ts
+++ b/denops/aider/bufferOperation.ts
@@ -55,13 +55,13 @@ export async function exitAiderBuffer(denops: Denops): Promise<void> {
 export async function openAiderBuffer(
   denops: Denops,
   openBufferType: BufferLayout,
-): Promise<undefined | boolean> {
+): Promise<void> {
   const aiderBuf = await getAiderBuffer(denops);
   // TODO openBufferTypeで大きく分岐するようリファクタすべき
   // return typeもbooleanにできる
   if (aiderBuf && openBufferType === "floating") {
     await openFloatingWindow(denops, aiderBuf.bufnr);
-    return true;
+    return;
   }
 
   if (openBufferType === "split" || openBufferType === "vsplit") {
@@ -70,13 +70,14 @@ export async function openAiderBuffer(
     } else {
       await openSplitWindow(denops);
     }
+    await aider().run(denops);
     return;
   }
 
   const bufnr = ensure(await n.nvim_create_buf(denops, false, true), is.Number);
 
   await openFloatingWindow(denops, bufnr);
-
+  await aider().run(denops);
   return;
 }
 

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -22,9 +22,11 @@ export async function main(denops: Denops): Promise<void> {
    * "0"の場合は引数なしの関数、"1"の場合は1つの引数を取る関数、
    * "*"の場合は2つの引数を取る関数を意味します。
    */
-  type ImplType<T extends ArgCount> = T extends "0" ? () => Promise<void>
-    : T extends "1" ? (arg: string) => Promise<void>
-    : (arg: string, arg2: string) => Promise<void>; // MEMO: ArgCountは*だが現状2つのみ対応している
+  type ImplType<T extends ArgCount> = T extends "0"
+    ? () => Promise<void>
+    : T extends "1"
+      ? (arg: string) => Promise<void>
+      : (arg: string, arg2: string) => Promise<void>; // MEMO: ArgCountは*だが現状2つのみ対応している
 
   /**
    * コマンドのオプションを定義
@@ -36,9 +38,11 @@ export async function main(denops: Denops): Promise<void> {
    * @property {boolean} [range] - 範囲指定が可能かどうかを示します。
    */
   type Opts<T extends ArgCount> = {
-    pattern?: T extends "0" ? undefined
-      : T extends "1" ? "[<f-args>]"
-      : "[<line1>, <line2>]";
+    pattern?: T extends "0"
+      ? undefined
+      : T extends "1"
+        ? "[<f-args>]"
+        : "[<line1>, <line2>]";
     complete?: T extends "1" ? "file" | "shellcmd" : undefined;
     range?: T extends "*" ? boolean : undefined;
   };
@@ -67,11 +71,9 @@ export async function main(denops: Denops): Promise<void> {
   ): Promise<Command> {
     const rangePart = opts.range ? "-range" : "";
 
-    const commandName = `Aider${dispatcherMethod.charAt(0).toUpperCase()}${
-      dispatcherMethod.slice(
-        1,
-      )
-    }`;
+    const commandName = `Aider${dispatcherMethod.charAt(0).toUpperCase()}${dispatcherMethod.slice(
+      1,
+    )}`;
     const completePart = opts.complete ? `-complete=${opts.complete}` : "";
     const patternPart = opts.pattern ?? "[]";
 
@@ -93,7 +95,7 @@ export async function main(denops: Denops): Promise<void> {
 
     await command("run", "0", async () => {
       const aiderBuf = await buffer.getAiderBuffer(denops);
-      await buffer.openAiderBuffer(denops, aiderBuf, openBufferType);
+      await buffer.openAiderBuffer(denops, openBufferType);
 
       if (aiderBuf === undefined) {
         await aider().run(denops);
@@ -129,8 +131,7 @@ export async function main(denops: Denops): Promise<void> {
         if (openBufferType === "floating") {
           await aider().silentRun(denops);
         } else {
-          const aiderBuf = await buffer.getAiderBuffer(denops);
-          await buffer.openAiderBuffer(denops, aiderBuf, openBufferType);
+          await buffer.openAiderBuffer(denops, openBufferType);
           await aider().run(denops);
           await denops.cmd("wincmd p");
           console.log("Run AiderAddCurrentFile again.");
@@ -162,8 +163,7 @@ export async function main(denops: Denops): Promise<void> {
         if (openBufferType === "floating") {
           await aider().silentRun(denops);
         } else {
-          const aiderBuf = await buffer.getAiderBuffer(denops);
-          await buffer.openAiderBuffer(denops, aiderBuf, openBufferType);
+          await buffer.openAiderBuffer(denops, openBufferType);
           await aider().run(denops);
           await denops.cmd("wincmd p");
           console.log("Run AiderAddReadCurrentFile again.");

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -94,13 +94,7 @@ export async function main(denops: Denops): Promise<void> {
     }),
 
     await command("run", "0", async () => {
-      const aiderBuf = await buffer.getAiderBuffer(denops);
       await buffer.openAiderBuffer(denops, openBufferType);
-
-      if (aiderBuf === undefined) {
-        await aider().run(denops);
-        return;
-      }
     }),
 
     await command("silentRun", "0", () => aider().silentRun(denops)),
@@ -132,7 +126,6 @@ export async function main(denops: Denops): Promise<void> {
           await aider().silentRun(denops);
         } else {
           await buffer.openAiderBuffer(denops, openBufferType);
-          await aider().run(denops);
           await denops.cmd("wincmd p");
           console.log("Run AiderAddCurrentFile again.");
           return;
@@ -164,7 +157,6 @@ export async function main(denops: Denops): Promise<void> {
           await aider().silentRun(denops);
         } else {
           await buffer.openAiderBuffer(denops, openBufferType);
-          await aider().run(denops);
           await denops.cmd("wincmd p");
           console.log("Run AiderAddReadCurrentFile again.");
           return;

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -22,11 +22,9 @@ export async function main(denops: Denops): Promise<void> {
    * "0"の場合は引数なしの関数、"1"の場合は1つの引数を取る関数、
    * "*"の場合は2つの引数を取る関数を意味します。
    */
-  type ImplType<T extends ArgCount> = T extends "0"
-    ? () => Promise<void>
-    : T extends "1"
-      ? (arg: string) => Promise<void>
-      : (arg: string, arg2: string) => Promise<void>; // MEMO: ArgCountは*だが現状2つのみ対応している
+  type ImplType<T extends ArgCount> = T extends "0" ? () => Promise<void>
+    : T extends "1" ? (arg: string) => Promise<void>
+    : (arg: string, arg2: string) => Promise<void>; // MEMO: ArgCountは*だが現状2つのみ対応している
 
   /**
    * コマンドのオプションを定義
@@ -38,11 +36,9 @@ export async function main(denops: Denops): Promise<void> {
    * @property {boolean} [range] - 範囲指定が可能かどうかを示します。
    */
   type Opts<T extends ArgCount> = {
-    pattern?: T extends "0"
-      ? undefined
-      : T extends "1"
-        ? "[<f-args>]"
-        : "[<line1>, <line2>]";
+    pattern?: T extends "0" ? undefined
+      : T extends "1" ? "[<f-args>]"
+      : "[<line1>, <line2>]";
     complete?: T extends "1" ? "file" | "shellcmd" : undefined;
     range?: T extends "*" ? boolean : undefined;
   };
@@ -71,9 +67,11 @@ export async function main(denops: Denops): Promise<void> {
   ): Promise<Command> {
     const rangePart = opts.range ? "-range" : "";
 
-    const commandName = `Aider${dispatcherMethod.charAt(0).toUpperCase()}${dispatcherMethod.slice(
-      1,
-    )}`;
+    const commandName = `Aider${dispatcherMethod.charAt(0).toUpperCase()}${
+      dispatcherMethod.slice(
+        1,
+      )
+    }`;
     const completePart = opts.complete ? `-complete=${opts.complete}` : "";
     const patternPart = opts.pattern ?? "[]";
 


### PR DESCRIPTION
- openAiderBufferのリファクタ中に増やして戻し忘れたaiderBuf引数を消します
- openAiderBufferとaider.run()をセットでやらないケースはあり得ないと思われるので、openAiderBuffer内でaider.run()するようにします
- aiderプロセスが死んでいるときのgetAiderBuffer内のbdの動作が怪しくなっていたのを修正します

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced buffer management for improved user experience when opening and interacting with Aider buffers.
- **Bug Fixes**
	- Streamlined command execution by removing unnecessary checks, leading to more efficient operations.
- **Refactor**
	- Updated function signatures for better clarity and consistency.
	- Improved code readability through formatting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->