### PR TITLE
assertAiderBufferString

### DIFF
--- a/denops/aider/mockAiderCommand.ts
+++ b/denops/aider/mockAiderCommand.ts
@@ -17,19 +17,11 @@ export const commands: AiderCommand = {
     await denops.cmd("b#"); // hide buffer
   },
 
-  sendPrompt: async (
-    denops: Denops,
-    _jobId: number,
-    prompt: string,
-  ): Promise<undefined> => {
-    await fn.feedkeys(denops, `input: ${prompt}\n`);
+  sendPrompt: async (denops: Denops, _jobId: number, prompt: string): Promise<undefined> => {
+    await fn.feedkeys(denops, `iinput: ${prompt}\n`);
   },
 
-  exit: async (
-    denops: Denops,
-    _jobId: number,
-    _bufnr: number,
-  ): Promise<undefined> => {
+  exit: async (denops: Denops, _jobId: number, _bufnr: number): Promise<undefined> => {
     if (mockAiderBufnr === undefined) {
       return;
     }

--- a/denops/aider/mockAiderCommand.ts
+++ b/denops/aider/mockAiderCommand.ts
@@ -18,7 +18,7 @@ export const commands: AiderCommand = {
   },
 
   sendPrompt: async (denops: Denops, _jobId: number, prompt: string): Promise<undefined> => {
-    await fn.feedkeys(denops, `iinput: ${prompt}\n`);
+    await fn.feedkeys(denops, `ainput: ${prompt}\n`, "x");
   },
 
   exit: async (denops: Denops, _jobId: number, _bufnr: number): Promise<undefined> => {

--- a/tests/aider_test.ts
+++ b/tests/aider_test.ts
@@ -26,5 +26,5 @@ test("vsplit", "AiderAddCurrentFile should work", async (denops) => {
   await denops.cmd("AiderAddCurrentFile");
   await sleep(10);
   await assertAiderBufferAlive(denops);
-  await assertAiderBufferString(denops, "");
+  await assertAiderBufferString(denops, ""); // "Run Command again." messgae is shown
 });

--- a/tests/aider_test.ts
+++ b/tests/aider_test.ts
@@ -1,5 +1,5 @@
 // This comment for vim-test plugin: Use denops' test() instead of built-in Deno.test()
-import { sleep } from "./assertions.ts";
+import { assertAiderBufferString, sleep } from "./assertions.ts";
 import { assertAiderBufferAlive } from "./assertions.ts";
 import { test } from "./testRunner.ts";
 
@@ -19,10 +19,12 @@ test("floating", "AiderAddCurrentFile should work", async (denops) => {
   await denops.cmd("AiderAddCurrentFile");
   await sleep(10);
   await assertAiderBufferAlive(denops);
+  await assertAiderBufferString(denops, "input: /add \n");
 });
 
 test("vsplit", "AiderAddCurrentFile should work", async (denops) => {
   await denops.cmd("AiderAddCurrentFile");
   await sleep(10);
   await assertAiderBufferAlive(denops);
+  await assertAiderBufferString(denops, "");
 });

--- a/tests/assertions.ts
+++ b/tests/assertions.ts
@@ -1,9 +1,9 @@
 import { assert } from "https://deno.land/std@0.217.0/assert/assert.ts";
+import { ensure, is } from "https://deno.land/x/unknownutil@v3.17.0/mod.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v6.4.0/mod.ts";
 import * as buffer from "../denops/aider/bufferOperation.ts";
 
-export const sleep = (msec: number) =>
-  new Promise((resolve) => setTimeout(resolve, msec));
+export const sleep = (msec: number) => new Promise((resolve) => setTimeout(resolve, msec));
 
 /**
  * Aiderバッファが開かれており、ウィンドウに表示されているかをアサートします
@@ -31,4 +31,11 @@ export async function assertAiderBufferHidden(denops: Denops): Promise<void> {
 export async function assertAiderBufferAlive(denops: Denops): Promise<void> {
   const buf = await buffer.getAiderBuffer(denops);
   assert(buf !== undefined);
+}
+
+export async function assertAiderBufferString(denops: Denops, expected: string): Promise<void> {
+  const buf = await buffer.getAiderBuffer(denops);
+  assert(buf !== undefined);
+  const lines = ensure(await denops.call("getbufline", buf.bufnr, 1, "$"), is.ArrayOf(is.String));
+  assert(lines.join("\n") === expected);
 }

--- a/tests/assertions.ts
+++ b/tests/assertions.ts
@@ -37,5 +37,6 @@ export async function assertAiderBufferString(denops: Denops, expected: string):
   const buf = await buffer.getAiderBuffer(denops);
   assert(buf !== undefined);
   const lines = ensure(await denops.call("getbufline", buf.bufnr, 1, "$"), is.ArrayOf(is.String));
-  assert(lines.join("\n") === expected);
+  const actual = lines.join("\n");
+  assert(actual === expected, `Buffer content mismatch.\nExpected:\n${expected}\nActual:\n${actual}`);
 }


### PR DESCRIPTION
- aiderバッファに何が入力されたかをアサートするassertAiderBufferStringを追加します


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `sendPrompt` method for improved command execution.
	- Added new assertion methods to validate Aider buffer content in tests.

- **Bug Fixes**
	- Improved formatting of the `exit` method for better readability.

- **Tests**
	- Expanded test coverage for `AiderAddCurrentFile` command with new assertions.

- **Chores**
	- Updated formatting of the `sleep` function for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->