### PR TITLE
Fix buffershown test

### DIFF
--- a/denops/aider/mockAiderCommand.ts
+++ b/denops/aider/mockAiderCommand.ts
@@ -8,7 +8,7 @@ let mockAiderBufnr: number | undefined = undefined;
 export const commands: AiderCommand = {
   run: async (denops: Denops): Promise<undefined> => {
     const bufnr = await fn.bufnr(denops, "%");
-    await denops.cmd("file mockaider"); // set buffer name
+    await denops.cmd("file dummyaider"); // set buffer name
 
     await emit(denops, "User", "AiderOpen");
     mockAiderBufnr = bufnr;

--- a/denops/aider/mockAiderCommand.ts
+++ b/denops/aider/mockAiderCommand.ts
@@ -7,13 +7,16 @@ let mockAiderBufnr: number | undefined = undefined;
 
 export const commands: AiderCommand = {
   run: async (denops: Denops): Promise<undefined> => {
-    const newBuf = await fn.bufnr(denops, "dummyaider", true);
+    const bufnr = await fn.bufnr(denops, "%");
+    await denops.cmd("file mockaider"); // set buffer name
+
     await emit(denops, "User", "AiderOpen");
-    mockAiderBufnr = newBuf;
+    mockAiderBufnr = bufnr;
   },
 
-  silentRun: async function (denops: Denops): Promise<undefined> {
-    await this.run(denops);
+  silentRun: async (denops: Denops): Promise<undefined> => {
+    await denops.cmd("enew");
+    await commands.run(denops);
     await denops.cmd("b#"); // hide buffer
   },
 

--- a/tests/aider_test.ts
+++ b/tests/aider_test.ts
@@ -1,18 +1,18 @@
 // This comment for vim-test plugin: Use denops' test() instead of built-in Deno.test()
-import { assertAiderBufferString, sleep } from "./assertions.ts";
+import { assertAiderBufferHidden, assertAiderBufferShown, assertAiderBufferString, sleep } from "./assertions.ts";
 import { assertAiderBufferAlive } from "./assertions.ts";
 import { test } from "./testRunner.ts";
 
 test("floating", "AiderRun should work", async (denops) => {
   await denops.cmd("AiderRun");
   await sleep(10);
-  await assertAiderBufferAlive(denops);
+  await assertAiderBufferShown(denops);
 });
 
 test("vsplit", "AiderRun should work", async (denops) => {
   await denops.cmd("AiderRun");
   await sleep(10);
-  await assertAiderBufferAlive(denops);
+  await assertAiderBufferShown(denops);
 });
 
 test("floating", "AiderAddCurrentFile should work", async (denops) => {
@@ -26,5 +26,20 @@ test("vsplit", "AiderAddCurrentFile should work", async (denops) => {
   await denops.cmd("AiderAddCurrentFile");
   await sleep(10);
   await assertAiderBufferAlive(denops);
-  await assertAiderBufferString(denops, ""); // "Run Command again." messgae is shown
+  await assertAiderBufferString(denops, "input: /add \n");
+});
+
+test("floating", "AiderSilentRun should work", async (denops) => {
+  // TODO if nothing is open, aider buffer is shown on the window(subtle bug)
+  await denops.cmd("e hoge.txt"); // open a buffer
+  await denops.cmd("AiderSilentRun");
+  await sleep(10);
+  await assertAiderBufferHidden(denops);
+});
+test("vsplit", "AiderSilentRun should work", async (denops) => {
+  // TODO if nothing is open, aider buffer is shown on the window(subtle bug)
+  await denops.cmd("e hoge.txt"); // open a buffer
+  await denops.cmd("AiderSilentRun");
+  await sleep(10);
+  await assertAiderBufferHidden(denops);
 });

--- a/tests/assertions.ts
+++ b/tests/assertions.ts
@@ -7,7 +7,6 @@ export const sleep = (msec: number) => new Promise((resolve) => setTimeout(resol
 
 /**
  * Aiderバッファが開かれており、ウィンドウに表示されているかをアサートします
- * うまく動いてない( ；´。 ｀；)
  */
 export async function assertAiderBufferShown(denops: Denops): Promise<void> {
   const buf = await buffer.getAiderBuffer(denops);
@@ -17,7 +16,6 @@ export async function assertAiderBufferShown(denops: Denops): Promise<void> {
 
 /**
  * Aiderバッファがウィンドウに表示されていないことをアサートします
- * うまく動いてない( ；´。 ｀；)
  */
 export async function assertAiderBufferHidden(denops: Denops): Promise<void> {
   const buf = await buffer.getAiderBuffer(denops);
@@ -33,6 +31,12 @@ export async function assertAiderBufferAlive(denops: Denops): Promise<void> {
   assert(buf !== undefined);
 }
 
+/**
+ * Aiderバッファの内容が期待される文字列と一致することをアサートします
+ *
+ * @param denops - Denopsインスタンス。
+ * @param expected - 期待されるバッファの内容。
+ */
 export async function assertAiderBufferString(denops: Denops, expected: string): Promise<void> {
   const buf = await buffer.getAiderBuffer(denops);
   assert(buf !== undefined);


### PR DESCRIPTION
- bufferShown/Hiddenのテストを修正しました :tada::tada::tada:
  - mockでバッファ新規作成するかどうかの動作がactualと違っていたのが原因でした
- aiderくんにassertAiderBufferStringのコメントを追加してもらいました（ ；´ワ ｀；）
![スクリーンショット 2024-10-12 16 34 20](https://github.com/user-attachments/assets/d1dd19a1-fe57-4c09-93e4-b17b5036b2f3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced buffer handling in the Aider command, allowing for dynamic buffer number retrieval.
  - Added a new function to assert the content of the Aider buffer.

- **Bug Fixes**
  - Updated assertions in test cases to ensure accurate verification of Aider buffer states.

- **Tests**
  - Introduced new test cases for the `AiderSilentRun` command.
  - Improved testing coverage with updated assertions for existing commands.

- **Documentation**
  - Removed outdated comments from assertion functions for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->