### PR TITLE
show buffers on assertion failure

### DIFF
--- a/tests/assertions.ts
+++ b/tests/assertions.ts
@@ -55,7 +55,7 @@ async function bufferStateMessage(denops: Denops): Promise<string> {
     const bufnr = ensure(await denops.call("bufnr", i), is.Number);
     const bufname = ensure(await denops.call("bufname", bufnr), is.String);
     const bufwinnr = ensure(await denops.call("bufwinnr", bufnr), is.Number);
-    message += `${JSON.stringify({ bufnr, bufname, bufwinnr })}\n`;
+    message += `${JSON.stringify({ bufwinnr, bufnr, bufname })}\n`;
   }
   return message;
 }

--- a/tests/assertions.ts
+++ b/tests/assertions.ts
@@ -10,8 +10,8 @@ export const sleep = (msec: number) => new Promise((resolve) => setTimeout(resol
  */
 export async function assertAiderBufferShown(denops: Denops): Promise<void> {
   const buf = await buffer.getAiderBuffer(denops);
-  assert(buf !== undefined);
-  assert(buf.winnr !== undefined);
+  assert(buf !== undefined, `Aider buffer is not defined.\n${await bufferStateMessage(denops)}`);
+  assert(buf.winnr !== undefined, `Aider buffer is not shown in any window.\n${await bufferStateMessage(denops)}`);
 }
 
 /**
@@ -19,8 +19,11 @@ export async function assertAiderBufferShown(denops: Denops): Promise<void> {
  */
 export async function assertAiderBufferHidden(denops: Denops): Promise<void> {
   const buf = await buffer.getAiderBuffer(denops);
-  assert(buf !== undefined);
-  assert(buf.winnr === undefined);
+  assert(buf !== undefined, `Aider buffer is not defined.\n${await bufferStateMessage(denops)}`);
+  assert(
+    buf.winnr === undefined,
+    `Aider buffer is shown in a window when it should be hidden.\n${await bufferStateMessage(denops)}`,
+  );
 }
 
 /**
@@ -28,7 +31,7 @@ export async function assertAiderBufferHidden(denops: Denops): Promise<void> {
  */
 export async function assertAiderBufferAlive(denops: Denops): Promise<void> {
   const buf = await buffer.getAiderBuffer(denops);
-  assert(buf !== undefined);
+  assert(buf !== undefined, `Aider buffer is not alive.\n${await bufferStateMessage(denops)}`);
 }
 
 /**
@@ -42,5 +45,17 @@ export async function assertAiderBufferString(denops: Denops, expected: string):
   assert(buf !== undefined);
   const lines = ensure(await denops.call("getbufline", buf.bufnr, 1, "$"), is.ArrayOf(is.String));
   const actual = lines.join("\n");
-  assert(actual === expected, `Buffer content mismatch.\nExpected:\n${expected}\nActual:\n${actual}`);
+  assert(actual === expected, `Buffer content mismatch.\nExpected:\n${expected}\nActual:\n${actual}\n`);
+}
+
+async function bufferStateMessage(denops: Denops): Promise<string> {
+  const bufCount = ensure(await denops.call("bufnr", "$"), is.Number);
+  let message = "";
+  for (let i = 1; i <= bufCount; i++) {
+    const bufnr = ensure(await denops.call("bufnr", i), is.Number);
+    const bufname = ensure(await denops.call("bufname", bufnr), is.String);
+    const bufwinnr = ensure(await denops.call("bufwinnr", bufnr), is.Number);
+    message += `${JSON.stringify({ bufnr, bufname, bufwinnr })}\n`;
+  }
+  return message;
 }


### PR DESCRIPTION
- バッファ関連のアサーション失敗時にバッファ一覧を表示するようになります
- PR時CIのテストも兼ねて

<img width="561" alt="スクリーンショット 2024-10-12 23 08 50" src="https://github.com/user-attachments/assets/5866aa26-94cf-4434-a7a0-6b0312387e78">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messages for assertions related to the Aider buffer, enhancing clarity during debugging.
	- Added detailed context for assertion failures, including buffer state information.

- **New Features**
	- Introduced a new helper function to compile and display the state of all buffers in error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->