### PR TITLE
feat: AiderAddFileBufferのユニットテストを追加

### DIFF
--- a/tests/aider_test.ts
+++ b/tests/aider_test.ts
@@ -25,3 +25,21 @@ test("both", "AiderSilentRun should work", async (denops) => {
   await sleep(SLEEP_BEFORE_ASSERT);
   await assertAiderBufferHidden(denops);
 });
+
+test("both", "AiderAddBuffers should return empty for files not under git management", async (denops) => {
+  await denops.cmd("AiderRun");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await denops.cmd("AiderAddBuffers");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await assertAiderBufferAlive(denops);
+  await assertAiderBufferString(denops, "input: /add \n");
+});
+
+test("both", "AiderAddBuffers should return /add `bufferName` if there is a buffer under git management", async (denops) => {
+  await denops.cmd("AiderRun");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await denops.cmd("e ./tests/aider_test.ts");
+  await denops.cmd("AiderAddBuffers");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await assertAiderBufferString(denops, "input: /add tests/aider_test.ts\n");
+});


### PR DESCRIPTION
テストは実装できました。

mstdnで話をしていた謎現象は、await denops.cmd("AiderRun");　の前に await denops.cmd("e ./path/to/file");を書くと、
Actualの値に読み込んだファイルのコードが混ざってしまっている。
これは、feedkeysの挙動に以下のような癖があるため、変な動きになっている模様( ；´。 ｀；)

https://qiita.com/machakann/items/32eb42a42fb65f753f86

```quote
:call feedkeys() を使う場合はキー入力を処理キューの最後尾に追加しそれが消費されるまで遅延することです。
```

自分は、ExpectedとActualに出力された文字列がぱっと見が同じなのにエラーになっていたため、以下の検証コードをassertAiderBufferString()に埋め込んで確認して気づいた。

```ts
  // 2. Visualize invisible characters
  console.log("Expected visible:", visualizeInvisible(expected));
  console.log("Actual visible:", visualizeInvisible(actual));
 
export function visualizeInvisible(text: string): string {
  // 視認しやすくするため極端にやっている
  return text.replace(/ /g, "[space]").replace(/\n/g, "[newline]");
}

```

結果( ;´｡ `;)
![CleanShot 2024-10-13 at 12 25 17@2x](https://github.com/user-attachments/assets/91da6c38-c558-4c8a-b283-506f9ccc03b2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced new test cases for the `AiderAddBuffers` command to enhance test coverage.
	- Verified functionality for both scenarios: files not under git management and files under git management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->