### PR TITLE
Refactor send prompt

### DIFF
--- a/denops/aider/actualAiderCommand.ts
+++ b/denops/aider/actualAiderCommand.ts
@@ -41,7 +41,7 @@ async function run(denops: Denops): Promise<undefined> {
  */
 async function sendPrompt(denops: Denops, jobId: number, prompt: string): Promise<undefined> {
   const promptLines = prompt.split("\n");
-  const joined = promptLines.join("\x1b\x0d"); // use Esc + Ctrl-M instead of \n to avoid sending cf. https://github.com/Aider-AI/aider/issues/901
+  const joined = promptLines.join("\x1b\x0d"); // use Esc + Ctrl-M instead of \n to avoid submit cf. https://github.com/Aider-AI/aider/issues/901
   await denops.call("chansend", jobId, `${joined}\n`);
 }
 

--- a/denops/aider/actualAiderCommand.ts
+++ b/denops/aider/actualAiderCommand.ts
@@ -40,10 +40,9 @@ async function run(denops: Denops): Promise<undefined> {
  * @returns {Promise<undefined>}
  */
 async function sendPrompt(denops: Denops, jobId: number, prompt: string): Promise<undefined> {
-  await v.r.set(denops, "q", prompt);
-  await fn.feedkeys(denops, "G");
-  await fn.feedkeys(denops, '"qp');
-  await denops.call("chansend", jobId, "\n");
+  const promptLines = prompt.split("\n");
+  promptLines.push("\n");
+  await denops.call("chansend", jobId, promptLines);
 }
 
 async function exit(denops: Denops, jobId: number, bufnr: number): Promise<undefined> {

--- a/denops/aider/actualAiderCommand.ts
+++ b/denops/aider/actualAiderCommand.ts
@@ -41,8 +41,8 @@ async function run(denops: Denops): Promise<undefined> {
  */
 async function sendPrompt(denops: Denops, jobId: number, prompt: string): Promise<undefined> {
   const promptLines = prompt.split("\n");
-  promptLines.push("\n");
-  await denops.call("chansend", jobId, promptLines);
+  const joined = promptLines.join("\x1b\x0d"); // use Esc + Ctrl-M instead of \n to avoid sending cf. https://github.com/Aider-AI/aider/issues/901
+  await denops.call("chansend", jobId, `${joined}\n`);
 }
 
 async function exit(denops: Denops, jobId: number, bufnr: number): Promise<undefined> {

--- a/denops/aider/bufferOperation.ts
+++ b/denops/aider/bufferOperation.ts
@@ -267,7 +267,6 @@ async function sendPromptFromFloatingWindow(denops: Denops, prompt: string): Pro
   if (aiderBuf === undefined) {
     return;
   }
-  await openFloatingWindow(denops, aiderBuf.bufnr);
 
   await aider().sendPrompt(denops, aiderBuf.jobId, prompt);
 }

--- a/denops/aider/bufferOperation.ts
+++ b/denops/aider/bufferOperation.ts
@@ -85,7 +85,7 @@ export async function prepareAiderBuffer(denops: Denops, openBufferType: BufferL
   }
 }
 
-export async function sendPrompt(denops: Denops, input: string): Promise<void> {
+export async function sendPrompt(denops: Denops, input: string, openBuf = true): Promise<void> {
   const aiderBuf = await getAiderBuffer(denops);
   if (aiderBuf === undefined) {
     await denops.cmd("echo 'Aider is not running'");
@@ -96,7 +96,9 @@ export async function sendPrompt(denops: Denops, input: string): Promise<void> {
   const openBufferType = await getOpenBufferType(denops);
 
   if (openBufferType === "floating") {
-    await openAiderBuffer(denops, openBufferType);
+    if (openBuf) {
+      await openAiderBuffer(denops, openBufferType);
+    }
     await sendPromptFromFloatingWindow(denops, input);
     return;
   }

--- a/denops/aider/bufferOperation.ts
+++ b/denops/aider/bufferOperation.ts
@@ -85,7 +85,7 @@ export async function prepareAiderBuffer(denops: Denops, openBufferType: BufferL
   }
 }
 
-export async function sendPrompt(denops: Denops, input: string, openBuf = true): Promise<void> {
+export async function sendPrompt(denops: Denops, input: string, opts = { openBuf: true }): Promise<void> {
   const aiderBuf = await getAiderBuffer(denops);
   if (aiderBuf === undefined) {
     await denops.cmd("echo 'Aider is not running'");
@@ -96,7 +96,7 @@ export async function sendPrompt(denops: Denops, input: string, openBuf = true):
   const openBufferType = await getOpenBufferType(denops);
 
   if (openBufferType === "floating") {
-    if (openBuf) {
+    if (opts?.openBuf) {
       await openAiderBuffer(denops, openBufferType);
     }
     await sendPromptFromFloatingWindow(denops, input);

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -1,10 +1,9 @@
+import { relative } from "https://deno.land/std@0.115.1/path/mod.ts";
 import * as fn from "https://deno.land/x/denops_std@v6.5.1/function/mod.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v6.5.1/mod.ts";
-import { aider } from "./aiderCommand.ts";
 import * as buffer from "./bufferOperation.ts";
 import type { BufferLayout } from "./bufferOperation.ts";
 import { getCurrentFilePath } from "./utils.ts";
-import { relative } from "https://deno.land/std@0.115.1/path/mod.ts";
 
 /**
  * The main function that sets up the Aider plugin functionality.

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -148,8 +148,6 @@ export async function main(denops: Denops): Promise<void> {
 
     await command("silentAddCurrentFile", "0", async () => {
       await addFileToAider(denops, openBufferType, "add", { openBuf: false });
-      await denops.cmd("fclose!");
-      await denops.cmd("silent! e!");
     }),
 
     await command(
@@ -171,8 +169,6 @@ export async function main(denops: Denops): Promise<void> {
       await addFileToAider(denops, openBufferType, "read-only", {
         openBuf: false,
       });
-      await denops.cmd("fclose!");
-      await denops.cmd("silent! e!");
     }),
 
     await command(

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -86,7 +86,7 @@ export async function main(denops: Denops): Promise<void> {
     denops: Denops,
     openBufferType: BufferLayout,
     prefix: string,
-    openBuf = true,
+    opts = { openBuf: true },
   ): Promise<void> {
     const currentBufnr = await fn.bufnr(denops, "%");
     const aiderBuffer = await buffer.getAiderBuffer(denops);
@@ -101,7 +101,7 @@ export async function main(denops: Denops): Promise<void> {
 
     const currentFile = await getCurrentFilePath(denops);
     const prompt = `/${prefix} ${currentFile}`;
-    await buffer.sendPrompt(denops, prompt, openBuf);
+    await buffer.sendPrompt(denops, prompt, opts);
   }
 
   const commands: Command[] = [
@@ -147,7 +147,7 @@ export async function main(denops: Denops): Promise<void> {
     }),
 
     await command("silentAddCurrentFile", "0", async () => {
-      await addFileToAider(denops, openBufferType, "add", false);
+      await addFileToAider(denops, openBufferType, "add", { openBuf: false });
       await denops.cmd("fclose!");
       await denops.cmd("silent! e!");
     }),
@@ -168,7 +168,9 @@ export async function main(denops: Denops): Promise<void> {
     }),
 
     await command("silentAddCurrentFileReadOnly", "0", async () => {
-      await addFileToAider(denops, openBufferType, "read-only", false);
+      await addFileToAider(denops, openBufferType, "read-only", {
+        openBuf: false,
+      });
       await denops.cmd("fclose!");
       await denops.cmd("silent! e!");
     }),

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -83,7 +83,12 @@ export async function main(denops: Denops): Promise<void> {
 
   const openBufferType: BufferLayout = await buffer.getOpenBufferType(denops);
 
-  async function addFileToAider(denops: Denops, openBufferType: BufferLayout, prefix: string): Promise<void> {
+  async function addFileToAider(
+    denops: Denops,
+    openBufferType: BufferLayout,
+    prefix: string,
+    openBuf = true,
+  ): Promise<void> {
     const currentBufnr = await fn.bufnr(denops, "%");
     const aiderBuffer = await buffer.getAiderBuffer(denops);
 
@@ -97,7 +102,7 @@ export async function main(denops: Denops): Promise<void> {
 
     const currentFile = await getCurrentFilePath(denops);
     const prompt = `/${prefix} ${currentFile}`;
-    await buffer.sendPrompt(denops, prompt);
+    await buffer.sendPrompt(denops, prompt, openBuf);
   }
 
   const commands: Command[] = [
@@ -143,7 +148,7 @@ export async function main(denops: Denops): Promise<void> {
     }),
 
     await command("silentAddCurrentFile", "0", async () => {
-      await addFileToAider(denops, openBufferType, "add");
+      await addFileToAider(denops, openBufferType, "add", false);
       await denops.cmd("fclose!");
       await denops.cmd("silent! e!");
     }),
@@ -164,7 +169,7 @@ export async function main(denops: Denops): Promise<void> {
     }),
 
     await command("silentAddCurrentFileReadOnly", "0", async () => {
-      await addFileToAider(denops, openBufferType, "read-only");
+      await addFileToAider(denops, openBufferType, "read-only", false);
       await denops.cmd("fclose!");
       await denops.cmd("silent! e!");
     }),


### PR DESCRIPTION
- aiderCommand.sendPrompt()でペーストを使うのをやめて全てjobIdへのchansendにすることでカレントバッファがaiderバッファでないときでもsendPromptできるようにしました
- silentAdd系のちらつきを解消しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced prompt sending functionality for improved user interaction with the Aider buffer.
	- Added flexibility in buffer opening behavior when sending prompts and adding files.

- **Bug Fixes**
	- Adjusted command implementations to prevent unintended buffer openings when adding current files.

- **Documentation**
	- Updated comments for clarity regarding changes in functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->