### PR TITLE
feat: 一時ファイルに選択したテキストを保存

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ To use aider.vim, you can run the following commands within Vim or Neovim:
 - `:AiderSilentAddCurrentFileReadOnly` - Silently adds the current file as read-only to aider's context.
 - `:AiderExit` - Exits aider and cleans up the session.
 - `:AiderVisualTextWithPrompt` - Edit the selected text in visual mode in a floating window and send it to aider. In the floating window, send to aider with `<CR>` in normal mode, and close the floating window with `Q`. You can also backup prompt with `q`.
+- `:AiderAddPartialReadonlyContext` - Adds the selected text in visual mode as read-only context to Aider.
 - `:AiderAddWeb` - Displays a prompt for the specified URL and adds it to the aider context.
 - `:AiderOpenIgnore` - Opens the `.aiderignore` file in the git root directory if it exists.
 - `:AiderAddIgnoreCurrentFile` - Adds the current file to the `.aiderignore`.

--- a/denops/aider/bufferOperation.ts
+++ b/denops/aider/bufferOperation.ts
@@ -430,3 +430,18 @@ export async function getFileBuffers(denops: Denops): Promise<undefined | string
 
   return buffers.join(" ") ?? undefined;
 }
+
+/**
+ * 選択したテキストを一時ファイルに保存し、ファイルのパスを返します。
+ *
+ * @param {Denops} denops - Denopsインスタンス
+ * @param {string} start - 選択範囲の開始行
+ * @param {string} end - 選択範囲の終了行
+ * @retuns {Promise<string>} 一時ファイルのパス
+ */
+export async function getPartialContextFilePath(denops: Denops, start: string, end: string): Promise<string> {
+  const buf_count = ensure(await fn.bufnr(denops, "$"), is.Number);
+  const s = ensure(start, is.String);
+  const e = ensure(end, is.String);
+  return `${s}:${e}:${buf_count}`;
+}

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -245,6 +245,16 @@ export async function main(denops: Denops): Promise<void> {
     }),
 
     await command(
+      "addPartialReadonlyContext",
+      "*",
+      async (start: string, end: string) => {
+        const partialContextFile = buffer.getPartialContextFilePath(denops, start, end);
+        // aider addする
+      },
+      { pattern: "[<line1>, <line2>]", range: true },
+    ),
+
+    await command(
       "visualTextWithPrompt",
       "*",
       async (start: string, end: string) => {

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -248,8 +248,9 @@ export async function main(denops: Denops): Promise<void> {
       "addPartialReadonlyContext",
       "*",
       async (start: string, end: string) => {
-        const partialContextFile = buffer.getPartialContextFilePath(denops, start, end);
-        // aider addする
+        const partialContextFile = await buffer.getPartialContextFilePath(denops, start, end);
+        const prompt = `/read-only ${partialContextFile}`;
+        await buffer.sendPrompt(denops, prompt);
       },
       { pattern: "[<line1>, <line2>]", range: true },
     ),


### PR DESCRIPTION
- partial context to temp file.
- /readonly tempfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new command `addPartialReadonlyContext` to the Aider plugin.
	- Introduced functionality to save selected text as a read-only context.
	- New command `:AiderAddPartialReadonlyContext` for users to add selected text in visual mode.

- **Improvements**
	- Enhanced text selection and context management capabilities with specific line ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->