### PR TITLE
Fix whisper typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ To use aider.vim, you can run the following commands within Vim or Neovim:
 - `:AiderPaste` - Pastes the content from the clipboard into the aider context.
 - `:AiderHideVisualSelectFloatingWindow` - Hides the visual selection floating
   window used for displaying selected text.
-- `:AiderVoice` - Sends voice commands to Aider(using wishper).
+- `:AiderVoice` - Sends voice commands to Aider (using Whisper).
 
 ### Advanced Usage
 


### PR DESCRIPTION
## Summary
- fix typo for `:AiderVoice` command description

## Testing
- `deno test ./tests/aider_test.ts` *(fails: deno: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo and improved formatting in the description of the `:AiderVoice` command in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->