### PR TITLE
feat(tmux): robust tmux exit and prevent layout change on AddCurrentFile

### DIFF
--- a/denops/aider/actualAiderCommand.ts
+++ b/denops/aider/actualAiderCommand.ts
@@ -143,7 +143,10 @@ async function exit(
     // Optionally kill the pane after sending exit
     await denops.call("system", `tmux kill-pane -t ${paneId}`);
     // Remove global to avoid stale pane references
-    await v.g.remove(denops, "aider_tmux_pane_id");
+    const exists = await denops.call("exists", "g:aider_tmux_pane_id");
+    if (exists === 1) {
+      await v.g.remove(denops, "aider_tmux_pane_id");
+    }
     return;
   }
 

--- a/denops/aider/bufferOperation.ts
+++ b/denops/aider/bufferOperation.ts
@@ -58,8 +58,11 @@ export async function exitAiderBuffer(denops: Denops): Promise<void> {
   const tmuxPaneId = await v.g.get(denops, "aider_tmux_pane_id");
   if (typeof tmuxPaneId === "string" && tmuxPaneId.length > 0) {
     await aider().exit(denops, 0, 0);
-    // Clear stale tmux pane id just in case
-    await v.g.remove(denops, "aider_tmux_pane_id");
+    // Ensure the global variable is cleared even in test/mock mode
+    const varExists = await denops.call("exists", "g:aider_tmux_pane_id");
+    if (varExists === 1) {
+      await v.g.remove(denops, "aider_tmux_pane_id");
+    }
   }
 }
 

--- a/denops/aider/main.ts
+++ b/denops/aider/main.ts
@@ -103,7 +103,17 @@ export async function main(denops: Denops): Promise<void> {
     const aiderBuffer = await buffer.getAiderBuffer(denops);
 
     if (!aiderBuffer) {
-      await buffer.prepareAiderBuffer(denops, openBufferType);
+      if (openBufferType === "floating") {
+        await buffer.prepareAiderBuffer(denops, openBufferType);
+      } else {
+        // In tmux split/vsplit mode, avoid re-attaching the pane (which changes layout)
+        const tmuxPaneId = await v.g.get(denops, "aider_tmux_pane_id");
+        const hasTmuxPane =
+          typeof tmuxPaneId === "string" && tmuxPaneId.length > 0;
+        if (!hasTmuxPane) {
+          await buffer.prepareAiderBuffer(denops, openBufferType);
+        }
+      }
     }
 
     if (await buffer.checkIfTerminalBuffer(denops, currentBufnr)) {
@@ -276,10 +286,7 @@ export async function main(denops: Denops): Promise<void> {
     ),
 
     await command("exit", "0", async () => {
-      const aiderBuffer = await buffer.getAiderBuffer(denops);
-      if (aiderBuffer) {
-        buffer.exitAiderBuffer(denops);
-      }
+      await buffer.exitAiderBuffer(denops);
     }),
 
     await command(

--- a/tests/aider_tmux_test.ts
+++ b/tests/aider_tmux_test.ts
@@ -63,3 +63,20 @@ test("vsplit", "tmux: AiderAddCurrentFile should work", async (denops) => {
   // Just ensure no error and buffer remains alive in tmux mode
   await assertAiderBufferAlive(denops);
 });
+
+test("vsplit", "tmux: AiderExit should clean up pane without buffer", async (denops) => {
+  await denops.cmd("let $TMUX = '1'");
+  // Simulate a previously created tmux pane id
+  await denops.cmd("let g:aider_tmux_pane_id = '%%pane%%'");
+
+  // Ensure there is no aider buffer (mock exit would have deleted it if existed)
+  // Directly call exit; should remove pane id without throwing
+  await denops.cmd("AiderExit");
+  await sleep(SLEEP);
+
+  // Verify aide tmux pane id is cleared
+  const hasPane = await denops.call("exists", "g:aider_tmux_pane_id");
+  if (hasPane === 1) {
+    throw new Error("tmux pane id should be cleared by AiderExit");
+  }
+});

--- a/tests/aider_tmux_test.ts
+++ b/tests/aider_tmux_test.ts
@@ -1,6 +1,6 @@
 import { test } from "./testRunner.ts";
 import { sleep } from "./assertions.ts";
-import { assertAiderBufferAlive } from "./assertions.ts";
+import { assertAiderBufferAlive, assertAiderBufferString } from "./assertions.ts";
 
 const SLEEP = 100;
 
@@ -26,5 +26,40 @@ test("vsplit", "tmux: AiderAddBuffers with file under git management", async (de
   await denops.cmd("AiderAddBuffers");
   await sleep(SLEEP);
   // In tmux mode, prompts are handled differently; just assert no error and buffer alive
+  await assertAiderBufferAlive(denops);
+});
+
+test("vsplit", "tmux: AiderSendPromptByCommandline should work", async (denops) => {
+  await denops.cmd("let $TMUX = '1'");
+
+  await denops.cmd("AiderRun");
+  await sleep(SLEEP);
+  await assertAiderBufferAlive(denops);
+
+  // Simulate that an aider tmux pane is active without invoking tmux binaries
+  await denops.cmd("let g:aider_tmux_pane_id = '%%pane%%'");
+
+  await denops.cmd("AiderSendPromptByCommandline tmux_prompt");
+  await sleep(SLEEP);
+  await assertAiderBufferString(denops, "input: tmux_prompt");
+});
+
+test("vsplit", "tmux: AiderAddCurrentFile should work", async (denops) => {
+  await denops.cmd("let $TMUX = '1'");
+
+  await denops.cmd("AiderRun");
+  await sleep(SLEEP);
+  await assertAiderBufferAlive(denops);
+
+  // Ensure we are not in the Aider window when opening a file
+  await denops.cmd("silent! wincmd p");
+  await denops.cmd("e ./tests/aider_test.ts");
+
+  // Simulate that an aider tmux pane is active without invoking tmux binaries
+  await denops.cmd("let g:aider_tmux_pane_id = '%%pane%%'");
+
+  await denops.cmd("AiderAddCurrentFile");
+  await sleep(SLEEP);
+  // Just ensure no error and buffer remains alive in tmux mode
   await assertAiderBufferAlive(denops);
 });


### PR DESCRIPTION
## Summary
- AiderExit: Always clean up tmux pane; guard missing var to avoid Vim(unlet):E108.
- AddCurrentFile: Skip prepare/reattach when tmux pane already exists to prevent join-pane from resizing layout.
- Tests: Add tmux-mode tests for prompt send, add-current-file behavior, and exit cleanup.

## Details
- :AiderExit now calls exit routine unconditionally and removes `g:aider_tmux_pane_id` only if it exists.
- In split/vsplit tmux mode, if `g:aider_tmux_pane_id` exists, do not call `prepareAiderBuffer` so layout stays unchanged.
- Updated `tests/aider_tmux_test.ts` and ensured suite passes.

## Test plan
- deno test --allow-env --allow-run --allow-net tests
- Verify 17 tests pass locally and in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of global variables to prevent errors when removing non-existent tmux pane IDs during exit and buffer operations.
  * Adjusted buffer preparation logic to avoid unnecessary actions when using tmux splits, ensuring a smoother layout experience.

* **Tests**
  * Added new tests to verify tmux-related functionality, including prompt sending, file addition, and proper cleanup of global variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->