### PR TITLE
fix: バッファ操作の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ deno.lock
 .vim/*
 .vim
 CONVENTION.md
+
+.mcp.json
+
+MEMO.md


### PR DESCRIPTION
以下の修正を含むプルリクエストです。

- denops/aider/bufferOperation.ts の修正（バッファ操作の改善・微調整）
- 機密情報を含む可能性があった .mcp.json はコミットから除外し、.gitignore に追加

目的:
- バッファ操作の信頼性と使い勝手の向上
- セキュリティ観点での不要ファイル除外

確認事項:
- 通常の操作フローでエラーが発生しないこと
- 既存機能へのリグレッションがないこと

問題なければ main へのマージをお願いします。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved tmux awareness: automatically detects the active pane and handles prompt delivery accordingly.
- Bug Fixes
  - Reduced race conditions during Aider startup, improving reliability when sending prompts from floating and split windows.
  - Ensures an Aider buffer/pane is created when needed, preventing no-op sends in certain setups.
- Improvements
  - More predictable behavior when no active tmux pane is available.
- Chores
  - Updated ignore list to exclude local config and notes files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->