### PR TITLE
feat: インタラクティブなキー送信機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ CONVENTION.md
 .mcp.json
 
 MEMO.md
+
+.serena/

--- a/tests/aider_send_key_test.ts
+++ b/tests/aider_send_key_test.ts
@@ -1,0 +1,148 @@
+// Test for AiderSendKey and AiderSendChoice commands
+import {
+  assertAiderBufferAlive,
+  assertAiderBufferString,
+  sleep,
+} from "./assertions.ts";
+import { test } from "./testRunner.ts";
+
+const SLEEP_BEFORE_ASSERT = 100;
+
+test("both", "AiderSendKey should send single character", async (denops) => {
+  // Setup: Start Aider in silent mode
+  await denops.cmd("AiderSilentRun");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await assertAiderBufferAlive(denops);
+  
+  // Simulate sending 'y' key
+  // Execute command asynchronously and then send key
+  await denops.cmd("call timer_start(50, {-> feedkeys('y', 't')})");
+  await denops.cmd("AiderSendKey");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  
+  // Assert the character was sent
+  await assertAiderBufferString(denops, "input: y");
+});
+
+test("both", "AiderSendKey should handle ESC cancellation", async (denops) => {
+  // Setup: Start Aider in silent mode
+  await denops.cmd("AiderSilentRun");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await assertAiderBufferAlive(denops);
+  
+  // Get initial buffer content
+  const initialContent = await denops.call("getbufline", "%", 1, "$") as string[];
+  
+  // Simulate ESC key (char code 27)
+  await denops.cmd("call timer_start(50, {-> feedkeys(\"\\<Esc>\", 't')})");
+  await denops.cmd("AiderSendKey");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  
+  // Assert nothing was sent (buffer content unchanged)
+  const afterContent = await denops.call("getbufline", "%", 1, "$") as string[];
+  if (initialContent.join("\n") !== afterContent.join("\n")) {
+    throw new Error("Buffer content changed when ESC was pressed");
+  }
+});
+
+test("both", "AiderSendKey should handle Enter key", async (denops) => {
+  // Setup: Start Aider in silent mode
+  await denops.cmd("AiderSilentRun");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await assertAiderBufferAlive(denops);
+  
+  // Simulate Enter key
+  await denops.cmd("call timer_start(50, {-> feedkeys(\"\\<CR>\", 't')})");
+  await denops.cmd("AiderSendKey");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  
+  // Assert newline was sent
+  await assertAiderBufferString(denops, "input: \n");
+});
+
+test("both", "AiderSendChoice should accept valid characters", async (denops) => {
+  // Setup: Start Aider in silent mode
+  await denops.cmd("AiderSilentRun");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await assertAiderBufferAlive(denops);
+  
+  // Simulate sending 'y' which is valid for "ynA"
+  await denops.cmd("call timer_start(50, {-> feedkeys('y', 't')})");
+  await denops.cmd("AiderSendChoice ynA");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  
+  // Assert the character was sent
+  await assertAiderBufferString(denops, "input: y");
+});
+
+test("both", "AiderSendChoice should reject invalid characters", async (denops) => {
+  // Setup: Start Aider in silent mode
+  await denops.cmd("AiderSilentRun");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await assertAiderBufferAlive(denops);
+  
+  // Get initial buffer content
+  const initialContent = await denops.call("getbufline", "%", 1, "$") as string[];
+  
+  // Simulate sending 'x' which is invalid for "ynA"
+  await denops.cmd("call timer_start(50, {-> feedkeys('x', 't')})");
+  await denops.cmd("AiderSendChoice ynA");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  
+  // Assert nothing was sent (buffer content unchanged)
+  const afterContent = await denops.call("getbufline", "%", 1, "$") as string[];
+  if (initialContent.join("\n") !== afterContent.join("\n")) {
+    throw new Error("Buffer content changed when invalid character was sent");
+  }
+});
+
+test("both", "AiderSendChoice should handle uppercase characters", async (denops) => {
+  // Setup: Start Aider in silent mode
+  await denops.cmd("AiderSilentRun");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await assertAiderBufferAlive(denops);
+  
+  // Simulate sending 'A' which is valid for "ynA"
+  await denops.cmd("call timer_start(50, {-> feedkeys('A', 't')})");
+  await denops.cmd("AiderSendChoice ynA");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  
+  // Assert the character was sent
+  await assertAiderBufferString(denops, "input: A");
+});
+
+test("both", "AiderSendChoice should work with numbers", async (denops) => {
+  // Setup: Start Aider in silent mode
+  await denops.cmd("AiderSilentRun");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await assertAiderBufferAlive(denops);
+  
+  // Simulate sending '2' which is valid for "123"
+  await denops.cmd("call timer_start(50, {-> feedkeys('2', 't')})");
+  await denops.cmd("AiderSendChoice 123");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  
+  // Assert the character was sent
+  await assertAiderBufferString(denops, "input: 2");
+});
+
+test("both", "AiderSendChoice should handle ESC cancellation", async (denops) => {
+  // Setup: Start Aider in silent mode
+  await denops.cmd("AiderSilentRun");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  await assertAiderBufferAlive(denops);
+  
+  // Get initial buffer content
+  const initialContent = await denops.call("getbufline", "%", 1, "$") as string[];
+  
+  // Simulate ESC key
+  await denops.cmd("call timer_start(50, {-> feedkeys(\"\\<Esc>\", 't')})");
+  await denops.cmd("AiderSendChoice ynA");
+  await sleep(SLEEP_BEFORE_ASSERT);
+  
+  // Assert nothing was sent (buffer content unchanged)
+  const afterContent = await denops.call("getbufline", "%", 1, "$") as string[];
+  if (initialContent.join("\n") !== afterContent.join("\n")) {
+    throw new Error("Buffer content changed when ESC was pressed");
+  }
+});


### PR DESCRIPTION
## 概要
AiderとのインタラクティブなキーボードI/Oのために、単一キー送信機能を追加しました。

## 追加機能

### 新しいコマンド
- **`:AiderSendKey`** - 任意の単一キーをAiderに送信する汎用コマンド
  - `getchar()`でユーザー入力を待機
  - ESCでキャンセル可能
  - Enterキーも送信可能

- **`:AiderSendChoice <validChars>`** - 指定された文字のみを受け付けて送信
  - 例: `:AiderSendChoice ynA` でy/n/Aのみ受け付け
  - 無効な入力時はエラーメッセージ表示

## 実装詳細
- 既存の`sendPrompt()`関数を活用
- floating/split/vsplit/tmux全レイアウトに対応
- 入力フィードバック表示機能付き

## テスト
- 16件のユニットテストを追加
- floatingとvsplitの両レイアウトでテスト実施
- 全テスト成功を確認

## 使用例
```vim
" 汎用キー送信
nnoremap <silent> <leader>ak :AiderSendKey<CR>

" y/n/Aの選択
nnoremap <silent> <leader>ay :AiderSendChoice ynA<CR>
```

## 動機
Aiderの対話型プロンプト（y/n/Aなど）に対して、Vimから直接応答できるようにするため。

## 変更内容
- `denops/aider/main.ts`: 新しいコマンドの実装を追加
- `tests/aider_send_key_test.ts`: ユニットテストを追加
- `.gitignore`: .serenaディレクトリを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added commands to capture a single key or choose from a set and send it to Aider without opening the buffer. ESC cancels; Enter sends a newline; invalid choices are rejected with a prompt.
* Tests
  * Added automated tests for key capture, choice validation, cancellation, and newline handling.
* Chores
  * Updated ignore rules to exclude a tooling directory from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->